### PR TITLE
[3] Comprehensive unit tests and OpKey/TxKey custom types

### DIFF
--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -4,6 +4,9 @@ pragma solidity ^0.8.24;
 import {BlockNumber} from "./BlockNumber.sol";
 import {ShortString} from "@openzeppelin/contracts/utils/ShortStrings.sol";
 
+type OpKey is uint256;
+type TxKey is uint256;
+
 /// @title EntityHashing
 /// @dev Pure encoding and hashing scheme for the Arkiv EntityRegistry.
 ///
@@ -261,23 +264,16 @@ library EntityHashing {
     // Storage key packing
     // -------------------------------------------------------------------------
 
-    /// @notice Pack a (block, tx, op) triple into a single uint256 key for
-    /// the `_hashAt` mapping. Layout: block in bits [64..127], tx in bits
-    /// [32..63], op in bits [0..31].
-    /// @param blockNumber Block number (uint64 range).
-    /// @param txSeq       Transaction sequence within the block.
-    /// @param opSeq       Operation sequence within the transaction.
-    /// @return The packed mapping key.
-    function packHashKey(uint256 blockNumber, uint32 txSeq, uint32 opSeq) internal pure returns (uint256) {
-        return (blockNumber << 64) | (uint256(txSeq) << 32) | opSeq;
+    /// @notice Pack a (block, tx) pair into a TxKey for the `_txOpCount`
+    /// mapping. Layout: block in bits [32..95], tx in bits [0..31].
+    function txKey(uint256 blockNumber, uint32 txSeq) internal pure returns (TxKey) {
+        return TxKey.wrap((blockNumber << 32) | txSeq);
     }
 
-    /// @notice Pack a (block, tx) pair into a single uint256 key for the
-    /// `_txOpCount` mapping. Layout: block in bits [32..95], tx in bits [0..31].
-    /// @param blockNumber Block number (uint64 range).
-    /// @param txSeq       Transaction sequence within the block.
-    /// @return The packed mapping key.
-    function packTxKey(uint256 blockNumber, uint32 txSeq) internal pure returns (uint256) {
-        return (blockNumber << 32) | txSeq;
+    /// @notice Pack a (block, tx, op) triple into an OpKey for the `_hashAt`
+    /// mapping. Layout: block in bits [64..127], tx in bits [32..63], op in
+    /// bits [0..31]. Extends txKey with the op dimension.
+    function opKey(uint256 blockNumber, uint32 txSeq, uint32 opSeq) internal pure returns (OpKey) {
+        return OpKey.wrap((TxKey.unwrap(txKey(blockNumber, txSeq)) << 32) | opSeq);
     }
 }

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.24;
 
 import {BlockNumber} from "./BlockNumber.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
-import {EntityHashing} from "./EntityHashing.sol";
+import {EntityHashing, OpKey, TxKey} from "./EntityHashing.sol";
 
 /// @title EntityRegistry
 /// @dev Stateful entity registry. All encoding and hashing logic is delegated
@@ -23,21 +23,21 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
 
     // Three-level changeset hash lookup table.
     //
-    // Key: EntityHashing.packHashKey(blockNumber, txSeq, opSeq)
+    // Key: EntityHashing.opKey(blockNumber, txSeq, opSeq)
     //   (block, tx, op) → changeset hash after that specific op
     //
     // No redundant tx-level or block-level snapshots are stored.
     // Those are derived via counts:
-    //   tx hash   = _hashAt[packHashKey(block, tx, _txOpCount[packTxKey(block, tx)])]
+    //   tx hash   = _hashAt[opKey(block, tx, _txOpCount[txKey(block, tx)])]
     //   block hash = tx hash of last tx in block (via BlockNode.txCount)
     //
     // Traversal: for block M, walk txSeq 1..blocks[M].txCount,
-    //   for each tx walk opSeq 1.._txOpCount[packTxKey(M, txSeq)].
+    //   for each tx walk opSeq 1.._txOpCount[txKey(M, txSeq)].
     //   Across blocks, follow blocks[M].nextBlock.
-    mapping(uint256 blockTxOpIndex => bytes32 changeSetHash) internal _hashAt;
+    mapping(OpKey opKey => bytes32 changeSetHash) internal _hashAt;
 
-    // Key: EntityHashing.packTxKey(blockNumber, txSeq) → op count for that tx
-    mapping(uint256 blockTxKey => uint32 opCount) internal _txOpCount;
+    // Key: EntityHashing.txKey(blockNumber, txSeq) → op count for that tx
+    mapping(TxKey txKey => uint32 opCount) internal _txOpCount;
 
     // Block-level linked list: only blocks with mutations have entries.
     // Enables O(1) traversal across sparse blocks.
@@ -58,7 +58,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // -------------------------------------------------------------------------
 
     function changeSetHash() public view returns (bytes32) {
-        return _hashAt[EntityHashing.packHashKey(_headBlock, _currentTxSeq, _currentOpSeq)];
+        return _hashAt[EntityHashing.opKey(_headBlock, _currentTxSeq, _currentOpSeq)];
     }
 
     /// @notice Derive the entity key for an owner and nonce, bound to this
@@ -75,7 +75,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         if (ops.length == 0) revert EntityHashing.EmptyBatch();
 
         // Read previous hash before any counter mutations.
-        bytes32 hash = _hashAt[EntityHashing.packHashKey(_headBlock, _currentTxSeq, _currentOpSeq)];
+        bytes32 hash = _hashAt[EntityHashing.opKey(_headBlock, _currentTxSeq, _currentOpSeq)];
 
         // Block transition: advance the linked list when entering a new block.
         if (uint64(block.number) != _headBlock) {
@@ -90,8 +90,6 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         _currentTxSeq++;
         uint32 txSeq = _currentTxSeq;
         _blocks[block.number].txCount = txSeq;
-
-        uint256 txKey = EntityHashing.packHashKey(block.number, txSeq, 0);
 
         // Process ops — one SSTORE per op for the snapshot.
         uint32 opSeq = 0;
@@ -118,11 +116,11 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
 
             hash = EntityHashing.chainOp(hash, opType, key, entityHash_);
             opSeq++;
-            _hashAt[txKey | opSeq] = hash;
+            _hashAt[EntityHashing.opKey(block.number, txSeq, opSeq)] = hash;
         }
 
         // Record op count for this tx and update packed cursor.
-        _txOpCount[EntityHashing.packTxKey(block.number, txSeq)] = opSeq;
+        _txOpCount[EntityHashing.txKey(block.number, txSeq)] = opSeq;
         _currentOpSeq = opSeq;
     }
 
@@ -133,17 +131,17 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     function changeSetHashAtBlock(uint256 blockNumber) public view returns (bytes32) {
         uint32 txCount = _blocks[blockNumber].txCount;
         if (txCount == 0) return bytes32(0);
-        uint32 ops = _txOpCount[EntityHashing.packTxKey(blockNumber, txCount)];
-        return _hashAt[EntityHashing.packHashKey(blockNumber, txCount, ops)];
+        uint32 ops = _txOpCount[EntityHashing.txKey(blockNumber, txCount)];
+        return _hashAt[EntityHashing.opKey(blockNumber, txCount, ops)];
     }
 
     function changeSetHashAtTx(uint256 blockNumber, uint32 txSeq) public view returns (bytes32) {
-        uint32 ops = _txOpCount[EntityHashing.packTxKey(blockNumber, txSeq)];
-        return _hashAt[EntityHashing.packHashKey(blockNumber, txSeq, ops)];
+        uint32 ops = _txOpCount[EntityHashing.txKey(blockNumber, txSeq)];
+        return _hashAt[EntityHashing.opKey(blockNumber, txSeq, ops)];
     }
 
     function changeSetHashAtOp(uint256 blockNumber, uint32 txSeq, uint32 opSeq) public view returns (bytes32) {
-        return _hashAt[EntityHashing.packHashKey(blockNumber, txSeq, opSeq)];
+        return _hashAt[EntityHashing.opKey(blockNumber, txSeq, opSeq)];
     }
 
     function genesisBlock() public view returns (uint64) {
@@ -159,7 +157,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     }
 
     function txOpCount(uint256 blockNumber, uint32 txSeq) public view returns (uint32) {
-        return _txOpCount[EntityHashing.packTxKey(blockNumber, txSeq)];
+        return _txOpCount[EntityHashing.txKey(blockNumber, txSeq)];
     }
 
     // -------------------------------------------------------------------------

--- a/test/unit/AttributeHash.t.sol
+++ b/test/unit/AttributeHash.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {ShortString} from "@openzeppelin/contracts/utils/ShortStrings.sol";
 import {Base} from "../utils/Base.t.sol";
 import {Lib} from "../utils/Lib.sol";
 import {EntityHashing} from "../../src/EntityHashing.sol";
@@ -160,5 +161,69 @@ contract AttributeHashTest is Base {
 
         // THEN it matches the library's computation
         assertEq(registry.exposed_attributeHash(attr), expected);
+    }
+
+    // -------------------------------------------------------------------------
+    // Assembly correctness — fuzz against pure-Solidity reference
+    // -------------------------------------------------------------------------
+
+    /// @dev Reference implementation using only Solidity (no assembly).
+    /// Used to verify the assembly-optimised attributeHash produces
+    /// identical results across arbitrary inputs.
+    function _referenceAttributeHash(EntityHashing.Attribute memory attr) internal pure returns (bytes32) {
+        return keccak256(
+            abi.encode(
+                EntityHashing.ATTRIBUTE_TYPEHASH,
+                attr.name,
+                attr.valueType,
+                attr.fixedValue,
+                keccak256(bytes(attr.stringValue))
+            )
+        );
+    }
+
+    function test_attributeHash_fuzz_uint(bytes32 name, uint256 value) public {
+        // GIVEN an arbitrary UINT attribute
+        vm.assume(name != bytes32(0));
+        EntityHashing.Attribute memory attr = EntityHashing.Attribute({
+            name: ShortString.wrap(name),
+            valueType: EntityHashing.AttributeType.UINT,
+            fixedValue: bytes32(value),
+            stringValue: ""
+        });
+
+        // WHEN hashing via the assembly implementation
+        // THEN it matches the pure-Solidity reference
+        assertEq(registry.exposed_attributeHash(attr), _referenceAttributeHash(attr));
+    }
+
+    function test_attributeHash_fuzz_entityKey(bytes32 name, bytes32 value) public {
+        // GIVEN an arbitrary ENTITY_KEY attribute
+        vm.assume(name != bytes32(0));
+        EntityHashing.Attribute memory attr = EntityHashing.Attribute({
+            name: ShortString.wrap(name),
+            valueType: EntityHashing.AttributeType.ENTITY_KEY,
+            fixedValue: value,
+            stringValue: ""
+        });
+
+        // WHEN hashing via the assembly implementation
+        // THEN it matches the pure-Solidity reference
+        assertEq(registry.exposed_attributeHash(attr), _referenceAttributeHash(attr));
+    }
+
+    function test_attributeHash_fuzz_string(bytes32 name, string calldata value) public {
+        // GIVEN an arbitrary STRING attribute
+        vm.assume(name != bytes32(0));
+        EntityHashing.Attribute memory attr = EntityHashing.Attribute({
+            name: ShortString.wrap(name),
+            valueType: EntityHashing.AttributeType.STRING,
+            fixedValue: bytes32(0),
+            stringValue: value
+        });
+
+        // WHEN hashing via the assembly implementation
+        // THEN it matches the pure-Solidity reference
+        assertEq(registry.exposed_attributeHash(attr), _referenceAttributeHash(attr));
     }
 }

--- a/test/unit/ChainOp.t.sol
+++ b/test/unit/ChainOp.t.sol
@@ -88,17 +88,11 @@ contract ChainOpTest is Base {
         bytes32 hashB = keccak256("hb");
 
         bytes32 chainAB = EntityHashing.chainOp(
-            EntityHashing.chainOp(bytes32(0), EntityHashing.CREATE, keyA, hashA),
-            EntityHashing.CREATE,
-            keyB,
-            hashB
+            EntityHashing.chainOp(bytes32(0), EntityHashing.CREATE, keyA, hashA), EntityHashing.CREATE, keyB, hashB
         );
 
         bytes32 chainBA = EntityHashing.chainOp(
-            EntityHashing.chainOp(bytes32(0), EntityHashing.CREATE, keyB, hashB),
-            EntityHashing.CREATE,
-            keyA,
-            hashA
+            EntityHashing.chainOp(bytes32(0), EntityHashing.CREATE, keyB, hashB), EntityHashing.CREATE, keyA, hashA
         );
 
         // THEN the resulting hashes differ

--- a/test/unit/ChainOp.t.sol
+++ b/test/unit/ChainOp.t.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Base} from "../utils/Base.t.sol";
+import {EntityHashing} from "../../src/EntityHashing.sol";
+
+contract ChainOpTest is Base {
+    // -------------------------------------------------------------------------
+    // Determinism
+    // -------------------------------------------------------------------------
+
+    function test_chainOp_deterministic() public pure {
+        // GIVEN the same inputs
+        bytes32 prev = keccak256("prev");
+        bytes32 key = keccak256("key");
+        bytes32 entityHash = keccak256("entity");
+
+        // WHEN computing chainOp twice
+        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, entityHash);
+        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, entityHash);
+
+        // THEN the hashes are equal
+        assertEq(hashA, hashB);
+    }
+
+    // -------------------------------------------------------------------------
+    // Different inputs produce different hashes
+    // -------------------------------------------------------------------------
+
+    function test_chainOp_differentPrev_differs() public pure {
+        // GIVEN two calls differing only in prev
+        bytes32 key = keccak256("key");
+        bytes32 entityHash = keccak256("entity");
+
+        bytes32 hashA = EntityHashing.chainOp(keccak256("prev1"), EntityHashing.OpType.CREATE, key, entityHash);
+        bytes32 hashB = EntityHashing.chainOp(keccak256("prev2"), EntityHashing.OpType.CREATE, key, entityHash);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_chainOp_differentOpType_differs() public pure {
+        // GIVEN two calls differing only in opType
+        bytes32 prev = keccak256("prev");
+        bytes32 key = keccak256("key");
+        bytes32 entityHash = keccak256("entity");
+
+        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, entityHash);
+        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.OpType.DELETE, key, entityHash);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_chainOp_differentKey_differs() public pure {
+        // GIVEN two calls differing only in key
+        bytes32 prev = keccak256("prev");
+        bytes32 entityHash = keccak256("entity");
+
+        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, keccak256("k1"), entityHash);
+        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, keccak256("k2"), entityHash);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_chainOp_differentEntityHash_differs() public pure {
+        // GIVEN two calls differing only in entityHash
+        bytes32 prev = keccak256("prev");
+        bytes32 key = keccak256("key");
+
+        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, keccak256("e1"));
+        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, keccak256("e2"));
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    // -------------------------------------------------------------------------
+    // Chaining — order matters
+    // -------------------------------------------------------------------------
+
+    function test_chainOp_orderMatters() public pure {
+        // GIVEN two ops chained in different order
+        bytes32 keyA = keccak256("a");
+        bytes32 hashA = keccak256("ha");
+        bytes32 keyB = keccak256("b");
+        bytes32 hashB = keccak256("hb");
+
+        bytes32 chainAB = EntityHashing.chainOp(
+            EntityHashing.chainOp(bytes32(0), EntityHashing.OpType.CREATE, keyA, hashA),
+            EntityHashing.OpType.CREATE,
+            keyB,
+            hashB
+        );
+
+        bytes32 chainBA = EntityHashing.chainOp(
+            EntityHashing.chainOp(bytes32(0), EntityHashing.OpType.CREATE, keyB, hashB),
+            EntityHashing.OpType.CREATE,
+            keyA,
+            hashA
+        );
+
+        // THEN the resulting hashes differ
+        assertNotEq(chainAB, chainBA);
+    }
+
+    function test_chainOp_fromZero_nonZero() public pure {
+        // GIVEN chaining from a zero prev hash (initial state)
+        bytes32 key = keccak256("key");
+        bytes32 entityHash = keccak256("entity");
+
+        // WHEN computing
+        bytes32 result = EntityHashing.chainOp(bytes32(0), EntityHashing.OpType.CREATE, key, entityHash);
+
+        // THEN the result is non-zero
+        assertNotEq(result, bytes32(0));
+    }
+
+    // -------------------------------------------------------------------------
+    // All OpType variants produce distinct hashes
+    // -------------------------------------------------------------------------
+
+    function test_chainOp_allOpTypes_distinct() public pure {
+        // GIVEN the same prev, key, entityHash but every OpType
+        bytes32 prev = keccak256("prev");
+        bytes32 key = keccak256("key");
+        bytes32 entityHash = keccak256("entity");
+
+        bytes32 hCreate = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, entityHash);
+        bytes32 hUpdate = EntityHashing.chainOp(prev, EntityHashing.OpType.UPDATE, key, entityHash);
+        bytes32 hExtend = EntityHashing.chainOp(prev, EntityHashing.OpType.EXTEND, key, entityHash);
+        bytes32 hTransfer = EntityHashing.chainOp(prev, EntityHashing.OpType.TRANSFER, key, entityHash);
+        bytes32 hDelete = EntityHashing.chainOp(prev, EntityHashing.OpType.DELETE, key, entityHash);
+        bytes32 hExpire = EntityHashing.chainOp(prev, EntityHashing.OpType.EXPIRE, key, entityHash);
+
+        // THEN all 6 are distinct
+        bytes32[6] memory hashes = [hCreate, hUpdate, hExtend, hTransfer, hDelete, hExpire];
+        for (uint256 i = 0; i < 6; i++) {
+            for (uint256 j = i + 1; j < 6; j++) {
+                assertNotEq(hashes[i], hashes[j]);
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Assembly correctness — fuzz against pure-Solidity reference
+    // -------------------------------------------------------------------------
+
+    function test_chainOp_fuzz(bytes32 prev, uint8 rawOpType, bytes32 key, bytes32 entityHash_) public pure {
+        // GIVEN arbitrary inputs, bound opType to valid range
+        rawOpType = uint8(bound(rawOpType, 0, 5));
+        EntityHashing.OpType opType = EntityHashing.OpType(rawOpType);
+
+        // WHEN computing via the assembly implementation
+        bytes32 actual = EntityHashing.chainOp(prev, opType, key, entityHash_);
+
+        // THEN it matches the pure-Solidity reference
+        bytes32 expected = keccak256(abi.encodePacked(prev, opType, key, entityHash_));
+        assertEq(actual, expected);
+    }
+}

--- a/test/unit/ChainOp.t.sol
+++ b/test/unit/ChainOp.t.sol
@@ -16,8 +16,8 @@ contract ChainOpTest is Base {
         bytes32 entityHash = keccak256("entity");
 
         // WHEN computing chainOp twice
-        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, entityHash);
-        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, entityHash);
+        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.CREATE, key, entityHash);
+        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.CREATE, key, entityHash);
 
         // THEN the hashes are equal
         assertEq(hashA, hashB);
@@ -32,8 +32,8 @@ contract ChainOpTest is Base {
         bytes32 key = keccak256("key");
         bytes32 entityHash = keccak256("entity");
 
-        bytes32 hashA = EntityHashing.chainOp(keccak256("prev1"), EntityHashing.OpType.CREATE, key, entityHash);
-        bytes32 hashB = EntityHashing.chainOp(keccak256("prev2"), EntityHashing.OpType.CREATE, key, entityHash);
+        bytes32 hashA = EntityHashing.chainOp(keccak256("prev1"), EntityHashing.CREATE, key, entityHash);
+        bytes32 hashB = EntityHashing.chainOp(keccak256("prev2"), EntityHashing.CREATE, key, entityHash);
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -45,8 +45,8 @@ contract ChainOpTest is Base {
         bytes32 key = keccak256("key");
         bytes32 entityHash = keccak256("entity");
 
-        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, entityHash);
-        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.OpType.DELETE, key, entityHash);
+        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.CREATE, key, entityHash);
+        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.DELETE, key, entityHash);
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -57,8 +57,8 @@ contract ChainOpTest is Base {
         bytes32 prev = keccak256("prev");
         bytes32 entityHash = keccak256("entity");
 
-        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, keccak256("k1"), entityHash);
-        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, keccak256("k2"), entityHash);
+        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.CREATE, keccak256("k1"), entityHash);
+        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.CREATE, keccak256("k2"), entityHash);
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -69,8 +69,8 @@ contract ChainOpTest is Base {
         bytes32 prev = keccak256("prev");
         bytes32 key = keccak256("key");
 
-        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, keccak256("e1"));
-        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, keccak256("e2"));
+        bytes32 hashA = EntityHashing.chainOp(prev, EntityHashing.CREATE, key, keccak256("e1"));
+        bytes32 hashB = EntityHashing.chainOp(prev, EntityHashing.CREATE, key, keccak256("e2"));
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -88,15 +88,15 @@ contract ChainOpTest is Base {
         bytes32 hashB = keccak256("hb");
 
         bytes32 chainAB = EntityHashing.chainOp(
-            EntityHashing.chainOp(bytes32(0), EntityHashing.OpType.CREATE, keyA, hashA),
-            EntityHashing.OpType.CREATE,
+            EntityHashing.chainOp(bytes32(0), EntityHashing.CREATE, keyA, hashA),
+            EntityHashing.CREATE,
             keyB,
             hashB
         );
 
         bytes32 chainBA = EntityHashing.chainOp(
-            EntityHashing.chainOp(bytes32(0), EntityHashing.OpType.CREATE, keyB, hashB),
-            EntityHashing.OpType.CREATE,
+            EntityHashing.chainOp(bytes32(0), EntityHashing.CREATE, keyB, hashB),
+            EntityHashing.CREATE,
             keyA,
             hashA
         );
@@ -111,7 +111,7 @@ contract ChainOpTest is Base {
         bytes32 entityHash = keccak256("entity");
 
         // WHEN computing
-        bytes32 result = EntityHashing.chainOp(bytes32(0), EntityHashing.OpType.CREATE, key, entityHash);
+        bytes32 result = EntityHashing.chainOp(bytes32(0), EntityHashing.CREATE, key, entityHash);
 
         // THEN the result is non-zero
         assertNotEq(result, bytes32(0));
@@ -127,12 +127,12 @@ contract ChainOpTest is Base {
         bytes32 key = keccak256("key");
         bytes32 entityHash = keccak256("entity");
 
-        bytes32 hCreate = EntityHashing.chainOp(prev, EntityHashing.OpType.CREATE, key, entityHash);
-        bytes32 hUpdate = EntityHashing.chainOp(prev, EntityHashing.OpType.UPDATE, key, entityHash);
-        bytes32 hExtend = EntityHashing.chainOp(prev, EntityHashing.OpType.EXTEND, key, entityHash);
-        bytes32 hTransfer = EntityHashing.chainOp(prev, EntityHashing.OpType.TRANSFER, key, entityHash);
-        bytes32 hDelete = EntityHashing.chainOp(prev, EntityHashing.OpType.DELETE, key, entityHash);
-        bytes32 hExpire = EntityHashing.chainOp(prev, EntityHashing.OpType.EXPIRE, key, entityHash);
+        bytes32 hCreate = EntityHashing.chainOp(prev, EntityHashing.CREATE, key, entityHash);
+        bytes32 hUpdate = EntityHashing.chainOp(prev, EntityHashing.UPDATE, key, entityHash);
+        bytes32 hExtend = EntityHashing.chainOp(prev, EntityHashing.EXTEND, key, entityHash);
+        bytes32 hTransfer = EntityHashing.chainOp(prev, EntityHashing.TRANSFER, key, entityHash);
+        bytes32 hDelete = EntityHashing.chainOp(prev, EntityHashing.DELETE, key, entityHash);
+        bytes32 hExpire = EntityHashing.chainOp(prev, EntityHashing.EXPIRE, key, entityHash);
 
         // THEN all 6 are distinct
         bytes32[6] memory hashes = [hCreate, hUpdate, hExtend, hTransfer, hDelete, hExpire];
@@ -150,13 +150,11 @@ contract ChainOpTest is Base {
     function test_chainOp_fuzz(bytes32 prev, uint8 rawOpType, bytes32 key, bytes32 entityHash_) public pure {
         // GIVEN arbitrary inputs, bound opType to valid range
         rawOpType = uint8(bound(rawOpType, 0, 5));
-        EntityHashing.OpType opType = EntityHashing.OpType(rawOpType);
-
         // WHEN computing via the assembly implementation
-        bytes32 actual = EntityHashing.chainOp(prev, opType, key, entityHash_);
+        bytes32 actual = EntityHashing.chainOp(prev, rawOpType, key, entityHash_);
 
         // THEN it matches the pure-Solidity reference
-        bytes32 expected = keccak256(abi.encodePacked(prev, opType, key, entityHash_));
+        bytes32 expected = keccak256(abi.encodePacked(prev, rawOpType, key, entityHash_));
         assertEq(actual, expected);
     }
 }

--- a/test/unit/CoreHash.t.sol
+++ b/test/unit/CoreHash.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {BlockNumber} from "../../src/BlockNumber.sol";
 import {Base} from "../utils/Base.t.sol";
 import {Lib} from "../utils/Lib.sol";
 import {EntityHashing} from "../../src/EntityHashing.sol";
@@ -17,8 +18,8 @@ contract CoreHashTest is Base {
         attrs[0] = Lib.uintAttr("count", 1);
 
         // WHEN computing coreHash twice with the same inputs
-        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
-        bytes32 hashB = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
+        bytes32 hashA = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
 
         // THEN the hashes are equal
         assertEq(hashA, hashB);
@@ -32,8 +33,8 @@ contract CoreHashTest is Base {
         // GIVEN two calls differing only in key
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
 
-        bytes32 hashA = registry.exposed_coreHash(keccak256("key1"), alice, 100, "text/plain", "hello", attrs);
-        bytes32 hashB = registry.exposed_coreHash(keccak256("key2"), alice, 100, "text/plain", "hello", attrs);
+        bytes32 hashA = registry.exposed_coreHash(keccak256("key1"), alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(keccak256("key2"), alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -44,8 +45,8 @@ contract CoreHashTest is Base {
         bytes32 key = keccak256("key");
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
 
-        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
-        bytes32 hashB = registry.exposed_coreHash(key, bob, 100, "text/plain", "hello", attrs);
+        bytes32 hashA = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(key, bob, BlockNumber.wrap(100), "text/plain", "hello", attrs);
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -56,8 +57,8 @@ contract CoreHashTest is Base {
         bytes32 key = keccak256("key");
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
 
-        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
-        bytes32 hashB = registry.exposed_coreHash(key, alice, 200, "text/plain", "hello", attrs);
+        bytes32 hashA = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, BlockNumber.wrap(200), "text/plain", "hello", attrs);
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -68,8 +69,8 @@ contract CoreHashTest is Base {
         bytes32 key = keccak256("key");
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
 
-        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
-        bytes32 hashB = registry.exposed_coreHash(key, alice, 100, "application/json", "hello", attrs);
+        bytes32 hashA = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "application/json", "hello", attrs);
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -80,8 +81,8 @@ contract CoreHashTest is Base {
         bytes32 key = keccak256("key");
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
 
-        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
-        bytes32 hashB = registry.exposed_coreHash(key, alice, 100, "text/plain", "world", attrs);
+        bytes32 hashA = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "world", attrs);
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -97,8 +98,8 @@ contract CoreHashTest is Base {
         EntityHashing.Attribute[] memory attrsB = new EntityHashing.Attribute[](1);
         attrsB[0] = Lib.uintAttr("count", 2);
 
-        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrsA);
-        bytes32 hashB = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrsB);
+        bytes32 hashA = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", attrsA);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", attrsB);
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -112,8 +113,8 @@ contract CoreHashTest is Base {
         EntityHashing.Attribute[] memory one = new EntityHashing.Attribute[](1);
         one[0] = Lib.uintAttr("count", 1);
 
-        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", empty);
-        bytes32 hashB = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", one);
+        bytes32 hashA = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", empty);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", one);
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -135,8 +136,8 @@ contract CoreHashTest is Base {
         attrsBA[0] = Lib.uintAttr("bbb", 2);
         attrsBA[1] = Lib.uintAttr("aaa", 1);
 
-        bytes32 hashAB = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrsAB);
-        bytes32 hashBA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrsBA);
+        bytes32 hashAB = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", attrsAB);
+        bytes32 hashBA = registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "hello", attrsBA);
 
         // THEN they differ — this is why the contract requires sorted attributes
         assertNotEq(hashAB, hashBA);
@@ -149,7 +150,7 @@ contract CoreHashTest is Base {
     function test_coreHash_matchesManualEIP712Encoding() public {
         // GIVEN inputs with two attributes
         bytes32 key = keccak256("key");
-        uint32 createdAt = 100;
+        BlockNumber createdAt = BlockNumber.wrap(100);
         bytes memory payload = "hello";
         string memory contentType = "text/plain";
 
@@ -190,7 +191,7 @@ contract CoreHashTest is Base {
                 EntityHashing.CORE_HASH_TYPEHASH,
                 key,
                 alice,
-                uint32(100),
+                BlockNumber.wrap(100),
                 keccak256(bytes("text/plain")),
                 keccak256(""),
                 keccak256(abi.encodePacked(attrHashes))
@@ -198,7 +199,7 @@ contract CoreHashTest is Base {
         );
 
         // THEN it matches the library
-        assertEq(registry.exposed_coreHash(key, alice, 100, "text/plain", "", attrs), expected);
+        assertEq(registry.exposed_coreHash(key, alice, BlockNumber.wrap(100), "text/plain", "", attrs), expected);
     }
 
     // -------------------------------------------------------------------------
@@ -208,11 +209,12 @@ contract CoreHashTest is Base {
     function test_coreHash_fuzz(
         bytes32 key,
         address creator,
-        uint32 createdAt,
+        uint32 rawCreatedAt,
         string calldata contentType,
         bytes calldata payload
     ) public {
         // GIVEN arbitrary core inputs with no attributes
+        BlockNumber createdAt = BlockNumber.wrap(rawCreatedAt);
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
 
         // WHEN computing via the assembly implementation

--- a/test/unit/CoreHash.t.sol
+++ b/test/unit/CoreHash.t.sol
@@ -33,8 +33,10 @@ contract CoreHashTest is Base {
         // GIVEN two calls differing only in key
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
 
-        bytes32 hashA = registry.exposed_coreHash(keccak256("key1"), alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
-        bytes32 hashB = registry.exposed_coreHash(keccak256("key2"), alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
+        bytes32 hashA =
+            registry.exposed_coreHash(keccak256("key1"), alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
+        bytes32 hashB =
+            registry.exposed_coreHash(keccak256("key2"), alice, BlockNumber.wrap(100), "text/plain", "hello", attrs);
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);

--- a/test/unit/CoreHash.t.sol
+++ b/test/unit/CoreHash.t.sol
@@ -1,0 +1,236 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Base} from "../utils/Base.t.sol";
+import {Lib} from "../utils/Lib.sol";
+import {EntityHashing} from "../../src/EntityHashing.sol";
+
+contract CoreHashTest is Base {
+    // -------------------------------------------------------------------------
+    // Determinism
+    // -------------------------------------------------------------------------
+
+    function test_coreHash_deterministic() public {
+        // GIVEN identical inputs
+        bytes32 key = keccak256("key");
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
+        attrs[0] = Lib.uintAttr("count", 1);
+
+        // WHEN computing coreHash twice with the same inputs
+        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
+
+        // THEN the hashes are equal
+        assertEq(hashA, hashB);
+    }
+
+    // -------------------------------------------------------------------------
+    // Different inputs produce different hashes
+    // -------------------------------------------------------------------------
+
+    function test_coreHash_differentKey_differs() public {
+        // GIVEN two calls differing only in key
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+
+        bytes32 hashA = registry.exposed_coreHash(keccak256("key1"), alice, 100, "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(keccak256("key2"), alice, 100, "text/plain", "hello", attrs);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_coreHash_differentCreator_differs() public {
+        // GIVEN two calls differing only in creator
+        bytes32 key = keccak256("key");
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+
+        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(key, bob, 100, "text/plain", "hello", attrs);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_coreHash_differentCreatedAt_differs() public {
+        // GIVEN two calls differing only in createdAt
+        bytes32 key = keccak256("key");
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+
+        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, 200, "text/plain", "hello", attrs);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_coreHash_differentContentType_differs() public {
+        // GIVEN two calls differing only in contentType
+        bytes32 key = keccak256("key");
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+
+        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, 100, "application/json", "hello", attrs);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_coreHash_differentPayload_differs() public {
+        // GIVEN two calls differing only in payload
+        bytes32 key = keccak256("key");
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+
+        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrs);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, 100, "text/plain", "world", attrs);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_coreHash_differentAttributes_differs() public {
+        // GIVEN two calls differing only in attribute values
+        bytes32 key = keccak256("key");
+
+        EntityHashing.Attribute[] memory attrsA = new EntityHashing.Attribute[](1);
+        attrsA[0] = Lib.uintAttr("count", 1);
+
+        EntityHashing.Attribute[] memory attrsB = new EntityHashing.Attribute[](1);
+        attrsB[0] = Lib.uintAttr("count", 2);
+
+        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrsA);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrsB);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_coreHash_emptyVsNonEmptyAttributes_differs() public {
+        // GIVEN one call with no attributes and one with attributes
+        bytes32 key = keccak256("key");
+
+        EntityHashing.Attribute[] memory empty = new EntityHashing.Attribute[](0);
+        EntityHashing.Attribute[] memory one = new EntityHashing.Attribute[](1);
+        one[0] = Lib.uintAttr("count", 1);
+
+        bytes32 hashA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", empty);
+        bytes32 hashB = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", one);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    // -------------------------------------------------------------------------
+    // Attribute order sensitivity
+    // -------------------------------------------------------------------------
+
+    function test_coreHash_attributeOrderMatters() public {
+        // GIVEN two attribute arrays with the same elements in different order
+        bytes32 key = keccak256("key");
+
+        EntityHashing.Attribute[] memory attrsAB = new EntityHashing.Attribute[](2);
+        attrsAB[0] = Lib.uintAttr("aaa", 1);
+        attrsAB[1] = Lib.uintAttr("bbb", 2);
+
+        EntityHashing.Attribute[] memory attrsBA = new EntityHashing.Attribute[](2);
+        attrsBA[0] = Lib.uintAttr("bbb", 2);
+        attrsBA[1] = Lib.uintAttr("aaa", 1);
+
+        bytes32 hashAB = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrsAB);
+        bytes32 hashBA = registry.exposed_coreHash(key, alice, 100, "text/plain", "hello", attrsBA);
+
+        // THEN they differ — this is why the contract requires sorted attributes
+        assertNotEq(hashAB, hashBA);
+    }
+
+    // -------------------------------------------------------------------------
+    // EIP-712 structure — manual encoding match
+    // -------------------------------------------------------------------------
+
+    function test_coreHash_matchesManualEIP712Encoding() public {
+        // GIVEN inputs with two attributes
+        bytes32 key = keccak256("key");
+        uint32 createdAt = 100;
+        bytes memory payload = "hello";
+        string memory contentType = "text/plain";
+
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](2);
+        attrs[0] = Lib.uintAttr("aaa", 10);
+        attrs[1] = Lib.stringAttr("bbb", "val");
+
+        // WHEN computing manually per EIP-712
+        bytes32[] memory attrHashes = new bytes32[](2);
+        attrHashes[0] = registry.exposed_attributeHash(attrs[0]);
+        attrHashes[1] = registry.exposed_attributeHash(attrs[1]);
+
+        bytes32 expected = keccak256(
+            abi.encode(
+                EntityHashing.CORE_HASH_TYPEHASH,
+                key,
+                alice,
+                createdAt,
+                keccak256(bytes(contentType)),
+                keccak256(payload),
+                keccak256(abi.encodePacked(attrHashes))
+            )
+        );
+
+        // THEN it matches the library's computation
+        assertEq(registry.exposed_coreHash(key, alice, createdAt, contentType, payload, attrs), expected);
+    }
+
+    function test_coreHash_emptyPayloadAndAttributes() public {
+        // GIVEN empty payload and no attributes
+        bytes32 key = keccak256("key");
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+
+        // WHEN computing manually
+        bytes32[] memory attrHashes = new bytes32[](0);
+        bytes32 expected = keccak256(
+            abi.encode(
+                EntityHashing.CORE_HASH_TYPEHASH,
+                key,
+                alice,
+                uint32(100),
+                keccak256(bytes("text/plain")),
+                keccak256(""),
+                keccak256(abi.encodePacked(attrHashes))
+            )
+        );
+
+        // THEN it matches the library
+        assertEq(registry.exposed_coreHash(key, alice, 100, "text/plain", "", attrs), expected);
+    }
+
+    // -------------------------------------------------------------------------
+    // Assembly correctness — fuzz against pure-Solidity reference
+    // -------------------------------------------------------------------------
+
+    function test_coreHash_fuzz(
+        bytes32 key,
+        address creator,
+        uint32 createdAt,
+        string calldata contentType,
+        bytes calldata payload
+    ) public {
+        // GIVEN arbitrary core inputs with no attributes
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+
+        // WHEN computing via the assembly implementation
+        bytes32 actual = registry.exposed_coreHash(key, creator, createdAt, contentType, payload, attrs);
+
+        // THEN it matches the pure-Solidity reference
+        bytes32[] memory attrHashes = new bytes32[](0);
+        bytes32 expected = keccak256(
+            abi.encode(
+                EntityHashing.CORE_HASH_TYPEHASH,
+                key,
+                creator,
+                createdAt,
+                keccak256(bytes(contentType)),
+                keccak256(payload),
+                keccak256(abi.encodePacked(attrHashes))
+            )
+        );
+        assertEq(actual, expected);
+    }
+}

--- a/test/unit/EntityKey.t.sol
+++ b/test/unit/EntityKey.t.sol
@@ -1,0 +1,88 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Base} from "../utils/Base.t.sol";
+import {EntityHashing} from "../../src/EntityHashing.sol";
+
+contract EntityKeyTest is Base {
+    // -------------------------------------------------------------------------
+    // Determinism
+    // -------------------------------------------------------------------------
+
+    function test_entityKey_deterministic() public view {
+        // GIVEN the same inputs
+        // WHEN computing entityKey twice
+        bytes32 keyA = EntityHashing.entityKey(block.chainid, address(registry), alice, 0);
+        bytes32 keyB = EntityHashing.entityKey(block.chainid, address(registry), alice, 0);
+
+        // THEN the keys are equal
+        assertEq(keyA, keyB);
+    }
+
+    // -------------------------------------------------------------------------
+    // Different inputs produce different keys
+    // -------------------------------------------------------------------------
+
+    function test_entityKey_differentOwner_differs() public view {
+        // GIVEN two different owners with the same nonce
+        bytes32 keyA = EntityHashing.entityKey(block.chainid, address(registry), alice, 0);
+        bytes32 keyB = EntityHashing.entityKey(block.chainid, address(registry), bob, 0);
+
+        // THEN the keys differ
+        assertNotEq(keyA, keyB);
+    }
+
+    function test_entityKey_differentNonce_differs() public view {
+        // GIVEN the same owner with different nonces
+        bytes32 keyA = EntityHashing.entityKey(block.chainid, address(registry), alice, 0);
+        bytes32 keyB = EntityHashing.entityKey(block.chainid, address(registry), alice, 1);
+
+        // THEN the keys differ
+        assertNotEq(keyA, keyB);
+    }
+
+    function test_entityKey_differentChainId_differs() public view {
+        // GIVEN two different chain IDs
+        bytes32 keyA = EntityHashing.entityKey(1, address(0xBEEF), alice, 0);
+        bytes32 keyB = EntityHashing.entityKey(999, address(0xBEEF), alice, 0);
+
+        // THEN the keys differ
+        assertNotEq(keyA, keyB);
+    }
+
+    function test_entityKey_differentRegistry_differs() public view {
+        // GIVEN two different registry addresses
+        bytes32 keyA = EntityHashing.entityKey(1, address(0xAAA), alice, 0);
+        bytes32 keyB = EntityHashing.entityKey(1, address(0xBBB), alice, 0);
+
+        // THEN the keys differ
+        assertNotEq(keyA, keyB);
+    }
+
+    // -------------------------------------------------------------------------
+    // EIP-712 structure — manual encoding match
+    // -------------------------------------------------------------------------
+
+    function test_entityKey_matchesManualComputation() public view {
+        // GIVEN known inputs
+        // WHEN computing manually
+        bytes32 expected = keccak256(abi.encodePacked(block.chainid, address(registry), alice, uint32(0)));
+
+        // THEN it matches the library
+        assertEq(EntityHashing.entityKey(block.chainid, address(registry), alice, 0), expected);
+    }
+
+    // -------------------------------------------------------------------------
+    // Assembly correctness — fuzz against pure-Solidity reference
+    // -------------------------------------------------------------------------
+
+    function test_entityKey_fuzz(uint256 chainId, address registryAddr, address owner, uint32 nonce) public pure {
+        // GIVEN arbitrary inputs
+        // WHEN computing via the assembly implementation
+        bytes32 actual = EntityHashing.entityKey(chainId, registryAddr, owner, nonce);
+
+        // THEN it matches the pure-Solidity reference
+        bytes32 expected = keccak256(abi.encodePacked(chainId, registryAddr, owner, nonce));
+        assertEq(actual, expected);
+    }
+}

--- a/test/unit/EntityStructHash.t.sol
+++ b/test/unit/EntityStructHash.t.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {BlockNumber} from "../../src/BlockNumber.sol";
 import {Base} from "../utils/Base.t.sol";
 import {EntityHashing} from "../../src/EntityHashing.sol";
 
@@ -14,8 +15,8 @@ contract EntityStructHashTest is Base {
         bytes32 core = keccak256("core");
 
         // WHEN computing entityStructHash twice
-        bytes32 hashA = EntityHashing.entityStructHash(core, alice, 100, 200);
-        bytes32 hashB = EntityHashing.entityStructHash(core, alice, 100, 200);
+        bytes32 hashA = EntityHashing.entityStructHash(core, alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
+        bytes32 hashB = EntityHashing.entityStructHash(core, alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
 
         // THEN the hashes are equal
         assertEq(hashA, hashB);
@@ -27,8 +28,8 @@ contract EntityStructHashTest is Base {
 
     function test_entityStructHash_differentCoreHash_differs() public view {
         // GIVEN two calls differing only in coreHash
-        bytes32 hashA = EntityHashing.entityStructHash(keccak256("core1"), alice, 100, 200);
-        bytes32 hashB = EntityHashing.entityStructHash(keccak256("core2"), alice, 100, 200);
+        bytes32 hashA = EntityHashing.entityStructHash(keccak256("core1"), alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
+        bytes32 hashB = EntityHashing.entityStructHash(keccak256("core2"), alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -38,8 +39,8 @@ contract EntityStructHashTest is Base {
         // GIVEN two calls differing only in owner
         bytes32 core = keccak256("core");
 
-        bytes32 hashA = EntityHashing.entityStructHash(core, alice, 100, 200);
-        bytes32 hashB = EntityHashing.entityStructHash(core, bob, 100, 200);
+        bytes32 hashA = EntityHashing.entityStructHash(core, alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
+        bytes32 hashB = EntityHashing.entityStructHash(core, bob, BlockNumber.wrap(100), BlockNumber.wrap(200));
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -49,8 +50,8 @@ contract EntityStructHashTest is Base {
         // GIVEN two calls differing only in updatedAt
         bytes32 core = keccak256("core");
 
-        bytes32 hashA = EntityHashing.entityStructHash(core, alice, 100, 200);
-        bytes32 hashB = EntityHashing.entityStructHash(core, alice, 150, 200);
+        bytes32 hashA = EntityHashing.entityStructHash(core, alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
+        bytes32 hashB = EntityHashing.entityStructHash(core, alice, BlockNumber.wrap(150), BlockNumber.wrap(200));
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -60,8 +61,8 @@ contract EntityStructHashTest is Base {
         // GIVEN two calls differing only in expiresAt
         bytes32 core = keccak256("core");
 
-        bytes32 hashA = EntityHashing.entityStructHash(core, alice, 100, 200);
-        bytes32 hashB = EntityHashing.entityStructHash(core, alice, 100, 300);
+        bytes32 hashA = EntityHashing.entityStructHash(core, alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
+        bytes32 hashB = EntityHashing.entityStructHash(core, alice, BlockNumber.wrap(100), BlockNumber.wrap(300));
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);
@@ -74,8 +75,8 @@ contract EntityStructHashTest is Base {
     function test_entityStructHash_matchesManualEIP712Encoding() public view {
         // GIVEN inputs
         bytes32 core = keccak256("core");
-        uint32 updatedAt = 100;
-        uint32 expiresAt = 200;
+        BlockNumber updatedAt = BlockNumber.wrap(100);
+        BlockNumber expiresAt = BlockNumber.wrap(200);
 
         // WHEN computing manually per EIP-712
         bytes32 expected = keccak256(abi.encode(EntityHashing.ENTITY_HASH_TYPEHASH, core, alice, updatedAt, expiresAt));
@@ -93,8 +94,8 @@ contract EntityStructHashTest is Base {
         bytes32 core = keccak256("core");
 
         // WHEN computing entityStructHash with different owners
-        bytes32 hashAlice = EntityHashing.entityStructHash(core, alice, 100, 200);
-        bytes32 hashBob = EntityHashing.entityStructHash(core, bob, 100, 200);
+        bytes32 hashAlice = EntityHashing.entityStructHash(core, alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
+        bytes32 hashBob = EntityHashing.entityStructHash(core, bob, BlockNumber.wrap(100), BlockNumber.wrap(200));
 
         // THEN the struct hashes differ (owner is in the outer hash)
         assertNotEq(hashAlice, hashBob);
@@ -105,8 +106,8 @@ contract EntityStructHashTest is Base {
         bytes32 core = keccak256("core");
 
         // WHEN computing entityStructHash with different expiry (simulating extend)
-        bytes32 hashOriginal = EntityHashing.entityStructHash(core, alice, 100, 200);
-        bytes32 hashExtended = EntityHashing.entityStructHash(core, alice, 150, 300);
+        bytes32 hashOriginal = EntityHashing.entityStructHash(core, alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
+        bytes32 hashExtended = EntityHashing.entityStructHash(core, alice, BlockNumber.wrap(150), BlockNumber.wrap(300));
 
         // THEN the struct hashes differ
         assertNotEq(hashOriginal, hashExtended);
@@ -116,11 +117,14 @@ contract EntityStructHashTest is Base {
     // Assembly correctness — fuzz against pure-Solidity reference
     // -------------------------------------------------------------------------
 
-    function test_entityStructHash_fuzz(bytes32 coreHash_, address owner, uint32 updatedAt, uint32 expiresAt)
+    function test_entityStructHash_fuzz(bytes32 coreHash_, address owner, uint32 rawUpdatedAt, uint32 rawExpiresAt)
         public
         pure
     {
         // GIVEN arbitrary inputs
+        BlockNumber updatedAt = BlockNumber.wrap(rawUpdatedAt);
+        BlockNumber expiresAt = BlockNumber.wrap(rawExpiresAt);
+
         // WHEN computing via the assembly implementation
         bytes32 actual = EntityHashing.entityStructHash(coreHash_, owner, updatedAt, expiresAt);
 

--- a/test/unit/EntityStructHash.t.sol
+++ b/test/unit/EntityStructHash.t.sol
@@ -28,8 +28,10 @@ contract EntityStructHashTest is Base {
 
     function test_entityStructHash_differentCoreHash_differs() public view {
         // GIVEN two calls differing only in coreHash
-        bytes32 hashA = EntityHashing.entityStructHash(keccak256("core1"), alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
-        bytes32 hashB = EntityHashing.entityStructHash(keccak256("core2"), alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
+        bytes32 hashA =
+            EntityHashing.entityStructHash(keccak256("core1"), alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
+        bytes32 hashB =
+            EntityHashing.entityStructHash(keccak256("core2"), alice, BlockNumber.wrap(100), BlockNumber.wrap(200));
 
         // THEN the hashes differ
         assertNotEq(hashA, hashB);

--- a/test/unit/EntityStructHash.t.sol
+++ b/test/unit/EntityStructHash.t.sol
@@ -1,0 +1,132 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Base} from "../utils/Base.t.sol";
+import {EntityHashing} from "../../src/EntityHashing.sol";
+
+contract EntityStructHashTest is Base {
+    // -------------------------------------------------------------------------
+    // Determinism
+    // -------------------------------------------------------------------------
+
+    function test_entityStructHash_deterministic() public view {
+        // GIVEN the same inputs
+        bytes32 core = keccak256("core");
+
+        // WHEN computing entityStructHash twice
+        bytes32 hashA = EntityHashing.entityStructHash(core, alice, 100, 200);
+        bytes32 hashB = EntityHashing.entityStructHash(core, alice, 100, 200);
+
+        // THEN the hashes are equal
+        assertEq(hashA, hashB);
+    }
+
+    // -------------------------------------------------------------------------
+    // Different inputs produce different hashes
+    // -------------------------------------------------------------------------
+
+    function test_entityStructHash_differentCoreHash_differs() public view {
+        // GIVEN two calls differing only in coreHash
+        bytes32 hashA = EntityHashing.entityStructHash(keccak256("core1"), alice, 100, 200);
+        bytes32 hashB = EntityHashing.entityStructHash(keccak256("core2"), alice, 100, 200);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_entityStructHash_differentOwner_differs() public view {
+        // GIVEN two calls differing only in owner
+        bytes32 core = keccak256("core");
+
+        bytes32 hashA = EntityHashing.entityStructHash(core, alice, 100, 200);
+        bytes32 hashB = EntityHashing.entityStructHash(core, bob, 100, 200);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_entityStructHash_differentUpdatedAt_differs() public view {
+        // GIVEN two calls differing only in updatedAt
+        bytes32 core = keccak256("core");
+
+        bytes32 hashA = EntityHashing.entityStructHash(core, alice, 100, 200);
+        bytes32 hashB = EntityHashing.entityStructHash(core, alice, 150, 200);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    function test_entityStructHash_differentExpiresAt_differs() public view {
+        // GIVEN two calls differing only in expiresAt
+        bytes32 core = keccak256("core");
+
+        bytes32 hashA = EntityHashing.entityStructHash(core, alice, 100, 200);
+        bytes32 hashB = EntityHashing.entityStructHash(core, alice, 100, 300);
+
+        // THEN the hashes differ
+        assertNotEq(hashA, hashB);
+    }
+
+    // -------------------------------------------------------------------------
+    // EIP-712 structure — manual encoding match
+    // -------------------------------------------------------------------------
+
+    function test_entityStructHash_matchesManualEIP712Encoding() public view {
+        // GIVEN inputs
+        bytes32 core = keccak256("core");
+        uint32 updatedAt = 100;
+        uint32 expiresAt = 200;
+
+        // WHEN computing manually per EIP-712
+        bytes32 expected = keccak256(abi.encode(EntityHashing.ENTITY_HASH_TYPEHASH, core, alice, updatedAt, expiresAt));
+
+        // THEN it matches the library's computation
+        assertEq(EntityHashing.entityStructHash(core, alice, updatedAt, expiresAt), expected);
+    }
+
+    // -------------------------------------------------------------------------
+    // Two-part structure property — coreHash stable across mutable fields
+    // -------------------------------------------------------------------------
+
+    function test_entityStructHash_coreHashStableAcrossOwnerChange() public view {
+        // GIVEN the same coreHash
+        bytes32 core = keccak256("core");
+
+        // WHEN computing entityStructHash with different owners
+        bytes32 hashAlice = EntityHashing.entityStructHash(core, alice, 100, 200);
+        bytes32 hashBob = EntityHashing.entityStructHash(core, bob, 100, 200);
+
+        // THEN the struct hashes differ (owner is in the outer hash)
+        assertNotEq(hashAlice, hashBob);
+    }
+
+    function test_entityStructHash_coreHashStableAcrossExpiryExtension() public view {
+        // GIVEN the same coreHash
+        bytes32 core = keccak256("core");
+
+        // WHEN computing entityStructHash with different expiry (simulating extend)
+        bytes32 hashOriginal = EntityHashing.entityStructHash(core, alice, 100, 200);
+        bytes32 hashExtended = EntityHashing.entityStructHash(core, alice, 150, 300);
+
+        // THEN the struct hashes differ
+        assertNotEq(hashOriginal, hashExtended);
+    }
+
+    // -------------------------------------------------------------------------
+    // Assembly correctness — fuzz against pure-Solidity reference
+    // -------------------------------------------------------------------------
+
+    function test_entityStructHash_fuzz(bytes32 coreHash_, address owner, uint32 updatedAt, uint32 expiresAt)
+        public
+        pure
+    {
+        // GIVEN arbitrary inputs
+        // WHEN computing via the assembly implementation
+        bytes32 actual = EntityHashing.entityStructHash(coreHash_, owner, updatedAt, expiresAt);
+
+        // THEN it matches the pure-Solidity reference
+        bytes32 expected =
+            keccak256(abi.encode(EntityHashing.ENTITY_HASH_TYPEHASH, coreHash_, owner, updatedAt, expiresAt));
+        assertEq(actual, expected);
+    }
+}

--- a/test/unit/Pack.t.sol
+++ b/test/unit/Pack.t.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Base} from "../utils/Base.t.sol";
+import {EntityHashing} from "../../src/EntityHashing.sol";
+
+contract PackTest is Base {
+    // =========================================================================
+    // packHashKey
+    // =========================================================================
+
+    // -------------------------------------------------------------------------
+    // Determinism
+    // -------------------------------------------------------------------------
+
+    function test_packHashKey_deterministic() public pure {
+        // GIVEN the same inputs
+        // WHEN packing twice
+        // THEN the results are equal
+        assertEq(EntityHashing.packHashKey(1, 2, 3), EntityHashing.packHashKey(1, 2, 3));
+    }
+
+    // -------------------------------------------------------------------------
+    // Different inputs produce different keys
+    // -------------------------------------------------------------------------
+
+    function test_packHashKey_differentBlock_differs() public pure {
+        assertNotEq(EntityHashing.packHashKey(1, 1, 1), EntityHashing.packHashKey(2, 1, 1));
+    }
+
+    function test_packHashKey_differentTx_differs() public pure {
+        assertNotEq(EntityHashing.packHashKey(1, 1, 1), EntityHashing.packHashKey(1, 2, 1));
+    }
+
+    function test_packHashKey_differentOp_differs() public pure {
+        assertNotEq(EntityHashing.packHashKey(1, 1, 1), EntityHashing.packHashKey(1, 1, 2));
+    }
+
+    // -------------------------------------------------------------------------
+    // Bit layout — manual verification
+    // -------------------------------------------------------------------------
+
+    function test_packHashKey_layout() public pure {
+        // GIVEN known inputs
+        uint256 blockNumber = 0xAB;
+        uint32 txSeq = 0xCD;
+        uint32 opSeq = 0xEF;
+
+        // WHEN packing
+        uint256 packed = EntityHashing.packHashKey(blockNumber, txSeq, opSeq);
+
+        // THEN it matches the expected bit layout: block << 64 | tx << 32 | op
+        uint256 expected = (0xAB << 64) | (uint256(0xCD) << 32) | 0xEF;
+        assertEq(packed, expected);
+    }
+
+    function test_packHashKey_zeroInputs() public pure {
+        // GIVEN all zeros
+        // THEN the packed key is zero
+        assertEq(EntityHashing.packHashKey(0, 0, 0), 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Assembly correctness — fuzz
+    // -------------------------------------------------------------------------
+
+    function test_packHashKey_fuzz(uint256 blockNumber, uint32 txSeq, uint32 opSeq) public pure {
+        // GIVEN arbitrary inputs
+        // WHEN packing via the library
+        uint256 actual = EntityHashing.packHashKey(blockNumber, txSeq, opSeq);
+
+        // THEN it matches the manual bit operation
+        uint256 expected = (blockNumber << 64) | (uint256(txSeq) << 32) | opSeq;
+        assertEq(actual, expected);
+    }
+
+    // =========================================================================
+    // packTxKey
+    // =========================================================================
+
+    // -------------------------------------------------------------------------
+    // Determinism
+    // -------------------------------------------------------------------------
+
+    function test_packTxKey_deterministic() public pure {
+        // GIVEN the same inputs
+        // WHEN packing twice
+        // THEN the results are equal
+        assertEq(EntityHashing.packTxKey(1, 2), EntityHashing.packTxKey(1, 2));
+    }
+
+    // -------------------------------------------------------------------------
+    // Different inputs produce different keys
+    // -------------------------------------------------------------------------
+
+    function test_packTxKey_differentBlock_differs() public pure {
+        assertNotEq(EntityHashing.packTxKey(1, 1), EntityHashing.packTxKey(2, 1));
+    }
+
+    function test_packTxKey_differentTx_differs() public pure {
+        assertNotEq(EntityHashing.packTxKey(1, 1), EntityHashing.packTxKey(1, 2));
+    }
+
+    // -------------------------------------------------------------------------
+    // Bit layout — manual verification
+    // -------------------------------------------------------------------------
+
+    function test_packTxKey_layout() public pure {
+        // GIVEN known inputs
+        uint256 blockNumber = 0xAB;
+        uint32 txSeq = 0xCD;
+
+        // WHEN packing
+        uint256 packed = EntityHashing.packTxKey(blockNumber, txSeq);
+
+        // THEN it matches the expected bit layout: block << 32 | tx
+        uint256 expected = (0xAB << 32) | 0xCD;
+        assertEq(packed, expected);
+    }
+
+    function test_packTxKey_zeroInputs() public pure {
+        // GIVEN all zeros
+        // THEN the packed key is zero
+        assertEq(EntityHashing.packTxKey(0, 0), 0);
+    }
+
+    // -------------------------------------------------------------------------
+    // Assembly correctness — fuzz
+    // -------------------------------------------------------------------------
+
+    function test_packTxKey_fuzz(uint256 blockNumber, uint32 txSeq) public pure {
+        // GIVEN arbitrary inputs
+        // WHEN packing via the library
+        uint256 actual = EntityHashing.packTxKey(blockNumber, txSeq);
+
+        // THEN it matches the manual bit operation
+        uint256 expected = (blockNumber << 32) | txSeq;
+        assertEq(actual, expected);
+    }
+}

--- a/test/unit/Pack.t.sol
+++ b/test/unit/Pack.t.sol
@@ -2,136 +2,149 @@
 pragma solidity ^0.8.24;
 
 import {Base} from "../utils/Base.t.sol";
-import {EntityHashing} from "../../src/EntityHashing.sol";
+import {EntityHashing, OpKey, TxKey} from "../../src/EntityHashing.sol";
 
 contract PackTest is Base {
     // =========================================================================
-    // packHashKey
+    // opKey
     // =========================================================================
 
     // -------------------------------------------------------------------------
     // Determinism
     // -------------------------------------------------------------------------
 
-    function test_packHashKey_deterministic() public pure {
+    function test_opKey_deterministic() public pure {
         // GIVEN the same inputs
         // WHEN packing twice
         // THEN the results are equal
-        assertEq(EntityHashing.packHashKey(1, 2, 3), EntityHashing.packHashKey(1, 2, 3));
+        assertEq(OpKey.unwrap(EntityHashing.opKey(1, 2, 3)), OpKey.unwrap(EntityHashing.opKey(1, 2, 3)));
     }
 
     // -------------------------------------------------------------------------
     // Different inputs produce different keys
     // -------------------------------------------------------------------------
 
-    function test_packHashKey_differentBlock_differs() public pure {
-        assertNotEq(EntityHashing.packHashKey(1, 1, 1), EntityHashing.packHashKey(2, 1, 1));
+    function test_opKey_differentBlock_differs() public pure {
+        assertNotEq(OpKey.unwrap(EntityHashing.opKey(1, 1, 1)), OpKey.unwrap(EntityHashing.opKey(2, 1, 1)));
     }
 
-    function test_packHashKey_differentTx_differs() public pure {
-        assertNotEq(EntityHashing.packHashKey(1, 1, 1), EntityHashing.packHashKey(1, 2, 1));
+    function test_opKey_differentTx_differs() public pure {
+        assertNotEq(OpKey.unwrap(EntityHashing.opKey(1, 1, 1)), OpKey.unwrap(EntityHashing.opKey(1, 2, 1)));
     }
 
-    function test_packHashKey_differentOp_differs() public pure {
-        assertNotEq(EntityHashing.packHashKey(1, 1, 1), EntityHashing.packHashKey(1, 1, 2));
+    function test_opKey_differentOp_differs() public pure {
+        assertNotEq(OpKey.unwrap(EntityHashing.opKey(1, 1, 1)), OpKey.unwrap(EntityHashing.opKey(1, 1, 2)));
     }
 
     // -------------------------------------------------------------------------
     // Bit layout — manual verification
     // -------------------------------------------------------------------------
 
-    function test_packHashKey_layout() public pure {
+    function test_opKey_layout() public pure {
         // GIVEN known inputs
         uint256 blockNumber = 0xAB;
         uint32 txSeq = 0xCD;
         uint32 opSeq = 0xEF;
 
         // WHEN packing
-        uint256 packed = EntityHashing.packHashKey(blockNumber, txSeq, opSeq);
+        uint256 packed = OpKey.unwrap(EntityHashing.opKey(blockNumber, txSeq, opSeq));
 
         // THEN it matches the expected bit layout: block << 64 | tx << 32 | op
         uint256 expected = (0xAB << 64) | (uint256(0xCD) << 32) | 0xEF;
         assertEq(packed, expected);
     }
 
-    function test_packHashKey_zeroInputs() public pure {
+    function test_opKey_zeroInputs() public pure {
         // GIVEN all zeros
         // THEN the packed key is zero
-        assertEq(EntityHashing.packHashKey(0, 0, 0), 0);
+        assertEq(OpKey.unwrap(EntityHashing.opKey(0, 0, 0)), 0);
     }
 
     // -------------------------------------------------------------------------
     // Assembly correctness — fuzz
     // -------------------------------------------------------------------------
 
-    function test_packHashKey_fuzz(uint256 blockNumber, uint32 txSeq, uint32 opSeq) public pure {
+    function test_opKey_fuzz(uint256 blockNumber, uint32 txSeq, uint32 opSeq) public pure {
         // GIVEN arbitrary inputs
         // WHEN packing via the library
-        uint256 actual = EntityHashing.packHashKey(blockNumber, txSeq, opSeq);
+        uint256 actual = OpKey.unwrap(EntityHashing.opKey(blockNumber, txSeq, opSeq));
 
         // THEN it matches the manual bit operation
         uint256 expected = (blockNumber << 64) | (uint256(txSeq) << 32) | opSeq;
         assertEq(actual, expected);
     }
 
+    // -------------------------------------------------------------------------
+    // opKey builds on txKey
+    // -------------------------------------------------------------------------
+
+    function test_opKey_extendsTxKey(uint64 blockNumber, uint32 txSeq, uint32 opSeq) public pure {
+        // GIVEN an opKey and its corresponding txKey (blockNumber bounded to uint64)
+        uint256 ok = OpKey.unwrap(EntityHashing.opKey(blockNumber, txSeq, opSeq));
+        uint256 tk = TxKey.unwrap(EntityHashing.txKey(blockNumber, txSeq));
+
+        // THEN the upper bits of opKey equal txKey shifted left by 32
+        assertEq(ok >> 32, tk);
+    }
+
     // =========================================================================
-    // packTxKey
+    // txKey
     // =========================================================================
 
     // -------------------------------------------------------------------------
     // Determinism
     // -------------------------------------------------------------------------
 
-    function test_packTxKey_deterministic() public pure {
+    function test_txKey_deterministic() public pure {
         // GIVEN the same inputs
         // WHEN packing twice
         // THEN the results are equal
-        assertEq(EntityHashing.packTxKey(1, 2), EntityHashing.packTxKey(1, 2));
+        assertEq(TxKey.unwrap(EntityHashing.txKey(1, 2)), TxKey.unwrap(EntityHashing.txKey(1, 2)));
     }
 
     // -------------------------------------------------------------------------
     // Different inputs produce different keys
     // -------------------------------------------------------------------------
 
-    function test_packTxKey_differentBlock_differs() public pure {
-        assertNotEq(EntityHashing.packTxKey(1, 1), EntityHashing.packTxKey(2, 1));
+    function test_txKey_differentBlock_differs() public pure {
+        assertNotEq(TxKey.unwrap(EntityHashing.txKey(1, 1)), TxKey.unwrap(EntityHashing.txKey(2, 1)));
     }
 
-    function test_packTxKey_differentTx_differs() public pure {
-        assertNotEq(EntityHashing.packTxKey(1, 1), EntityHashing.packTxKey(1, 2));
+    function test_txKey_differentTx_differs() public pure {
+        assertNotEq(TxKey.unwrap(EntityHashing.txKey(1, 1)), TxKey.unwrap(EntityHashing.txKey(1, 2)));
     }
 
     // -------------------------------------------------------------------------
     // Bit layout — manual verification
     // -------------------------------------------------------------------------
 
-    function test_packTxKey_layout() public pure {
+    function test_txKey_layout() public pure {
         // GIVEN known inputs
         uint256 blockNumber = 0xAB;
         uint32 txSeq = 0xCD;
 
         // WHEN packing
-        uint256 packed = EntityHashing.packTxKey(blockNumber, txSeq);
+        uint256 packed = TxKey.unwrap(EntityHashing.txKey(blockNumber, txSeq));
 
         // THEN it matches the expected bit layout: block << 32 | tx
         uint256 expected = (0xAB << 32) | 0xCD;
         assertEq(packed, expected);
     }
 
-    function test_packTxKey_zeroInputs() public pure {
+    function test_txKey_zeroInputs() public pure {
         // GIVEN all zeros
         // THEN the packed key is zero
-        assertEq(EntityHashing.packTxKey(0, 0), 0);
+        assertEq(TxKey.unwrap(EntityHashing.txKey(0, 0)), 0);
     }
 
     // -------------------------------------------------------------------------
     // Assembly correctness — fuzz
     // -------------------------------------------------------------------------
 
-    function test_packTxKey_fuzz(uint256 blockNumber, uint32 txSeq) public pure {
+    function test_txKey_fuzz(uint256 blockNumber, uint32 txSeq) public pure {
         // GIVEN arbitrary inputs
         // WHEN packing via the library
-        uint256 actual = EntityHashing.packTxKey(blockNumber, txSeq);
+        uint256 actual = TxKey.unwrap(EntityHashing.txKey(blockNumber, txSeq));
 
         // THEN it matches the manual bit operation
         uint256 expected = (blockNumber << 32) | txSeq;


### PR DESCRIPTION
- Add fuzz tests for `attributeHash` validating assembly against pure-Solidity reference
- Full unit test suites: `coreHash`, `entityKey`, `entityStructHash`, `chainOp`, packing — each covering determinism, input sensitivity, EIP-712 manual encoding match, and fuzz correctness
- Introduce `OpKey` and `TxKey` user-defined value types for the changeset index mappings, replacing raw `uint256` keys — invalid cross-use is now a compile error
- `opKey()` composes on `txKey()` internally