### PR TITLE
Implement _create with unit tests

### DIFF
--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -120,6 +120,9 @@ library EntityHashing {
     /// @dev Reverted when a STRING attribute value exceeds the maximum size.
     error StringAttributeTooLarge(bytes32 name, uint256 size, uint256 maxSize);
 
+    /// @dev Reverted when an attribute has non-zero unused fields.
+    error NonCanonicalAttribute(uint256 index);
+
     /// @dev Reverted when a payload exceeds the maximum size.
     error PayloadTooLarge(uint256 size, uint256 maxSize);
 

--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -114,17 +114,21 @@ library EntityHashing {
     /// @dev Reverted when an attribute has an empty name.
     error EmptyAttributeName(uint256 index);
 
-    /// @dev Reverted when a STRING attribute value exceeds the maximum size.
-    error StringAttributeTooLarge(bytes32 name, uint256 size, uint256 maxSize);
-
     /// @dev Reverted when an attribute has non-zero unused fields.
     error NonCanonicalAttribute(uint256 index);
 
-    /// @dev Reverted when a payload exceeds the maximum size.
-    error PayloadTooLarge(uint256 size, uint256 maxSize);
+    /// @dev Reverted when a STRING attribute value exceeds the maximum size.
+    error StringAttributeTooLarge(bytes32 name, uint256 size, uint256 maxSize);
 
     /// @dev Reverted when too many attributes are provided.
     error TooManyAttributes(uint256 count, uint256 maxCount);
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    uint256 internal constant MAX_ATTRIBUTES = 32;
+    uint256 internal constant MAX_STRING_ATTR_SIZE = 1024;
 
     // -------------------------------------------------------------------------
     // Constants — EIP-712 typehashes

--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -105,9 +105,6 @@ library EntityHashing {
 
     uint256 internal constant MAX_STRING_ATTR_SIZE = 1024;
 
-    /// @dev Reverted when an entity key already exists in storage.
-    error EntityAlreadyExists(bytes32 entityKey);
-
     /// @dev Reverted when expiresAt is not in the future.
     error ExpiryInPast(BlockNumber expiresAt, BlockNumber currentBlock);
 

--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -63,18 +63,21 @@ library EntityHashing {
         bytes value;
     }
 
-    /// @dev On-chain representation of a registered entity. Stored in the
-    /// EntityRegistry's entity mapping. The `attributes` array must be
-    /// sorted ascending by name to match the ordering enforced at creation.
-    struct Entity {
+    /// @dev On-chain entity commitment. Stores only the fields needed to
+    /// recompute entityHash from chain state alone — no payload or attributes.
+    /// Full entity data lives in calldata/events for the off-chain DB.
+    ///
+    /// Storage layout (3 slots):
+    ///   slot 0: creator (20) | createdAt (4) | updatedAt (4) | expiresAt (4) = 32 bytes
+    ///   slot 1: owner (20) | [12 bytes padding]
+    ///   slot 2: coreHash (32)
+    struct Commitment {
         address creator;
-        address owner;
         BlockNumber createdAt;
         BlockNumber updatedAt;
         BlockNumber expiresAt;
-        bytes payload;
-        string contentType;
-        Attribute[] attributes;
+        address owner;
+        bytes32 coreHash;
     }
 
     /// @dev Block-level linked list node for traversing mutation history.
@@ -101,6 +104,27 @@ library EntityHashing {
     // -------------------------------------------------------------------------
 
     uint256 internal constant MAX_STRING_ATTR_SIZE = 1024;
+
+    /// @dev Reverted when an entity key already exists in storage.
+    error EntityAlreadyExists(bytes32 entityKey);
+
+    /// @dev Reverted when expiresAt is not in the future.
+    error ExpiryInPast(BlockNumber expiresAt, BlockNumber currentBlock);
+
+    /// @dev Reverted when attributes are not sorted in strict ascending order by name.
+    error AttributesNotSorted(bytes32 current, bytes32 previous);
+
+    /// @dev Reverted when an attribute has an empty name.
+    error EmptyAttributeName(uint256 index);
+
+    /// @dev Reverted when a STRING attribute value exceeds the maximum size.
+    error StringAttributeTooLarge(bytes32 name, uint256 size, uint256 maxSize);
+
+    /// @dev Reverted when a payload exceeds the maximum size.
+    error PayloadTooLarge(uint256 size, uint256 maxSize);
+
+    /// @dev Reverted when too many attributes are provided.
+    error TooManyAttributes(uint256 count, uint256 maxCount);
 
     // -------------------------------------------------------------------------
     // Constants — EIP-712 typehashes

--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -98,29 +98,7 @@ library EntityHashing {
     error AttributesNotSorted();
     error InvalidValueLength(bytes32 name, uint8 valueType, uint256 length);
     error InvalidValueType(bytes32 name, uint8 valueType);
-
-    // -------------------------------------------------------------------------
-    // Constants — validation limits
-    // -------------------------------------------------------------------------
-
-    uint256 internal constant MAX_STRING_ATTR_SIZE = 1024;
-
-    /// @dev Reverted when expiresAt is not in the future.
     error ExpiryInPast(BlockNumber expiresAt, BlockNumber currentBlock);
-
-    /// @dev Reverted when attributes are not sorted in strict ascending order by name.
-    error AttributesNotSorted(bytes32 current, bytes32 previous);
-
-    /// @dev Reverted when an attribute has an empty name.
-    error EmptyAttributeName(uint256 index);
-
-    /// @dev Reverted when an attribute has non-zero unused fields.
-    error NonCanonicalAttribute(uint256 index);
-
-    /// @dev Reverted when a STRING attribute value exceeds the maximum size.
-    error StringAttributeTooLarge(bytes32 name, uint256 size, uint256 maxSize);
-
-    /// @dev Reverted when too many attributes are provided.
     error TooManyAttributes(uint256 count, uint256 maxCount);
 
     // -------------------------------------------------------------------------

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -192,6 +192,13 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         return _hashTypedDataV4(EntityHashing.entityStructHash(coreHash_, owner, updatedAt, expiresAt));
     }
 
+    /// @dev Mint a new entity key by post-incrementing the owner's nonce.
+    /// Uniqueness is guaranteed by the monotonic nonce — no existence check needed.
+    function _createEntityKey(address owner) internal returns (bytes32) {
+        uint32 nonce = nonces[owner]++;
+        return EntityHashing.entityKey(block.chainid, address(this), owner, nonce);
+    }
+
     // -------------------------------------------------------------------------
     // Internal functions — entity operations
     // -------------------------------------------------------------------------
@@ -245,10 +252,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
             revert EntityHashing.ExpiryInPast(op.expiresAt, current);
         }
 
-        // Derive a globally unique entity key: keccak256(chainId, registry, owner, nonce).
-        // The post-increment nonce guarantees uniqueness without an existence check.
-        uint32 nonce = nonces[msg.sender]++;
-        key = EntityHashing.entityKey(block.chainid, address(this), msg.sender, nonce);
+        key = _createEntityKey(msg.sender);
 
         // Two-level EIP-712 hash:
         //   coreHash: immutable content identity (survives transfers and expiry extensions)

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -54,7 +54,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // Events
     // -------------------------------------------------------------------------
 
-    event EntityCreated(bytes32 indexed entityKey, address indexed owner, bytes32 entityHash, BlockNumber expiresAt);
+    event EntityCreated(bytes32 indexed entityKey, address indexed owner, BlockNumber expiresAt, bytes32 entityHash);
 
     // -------------------------------------------------------------------------
     // State — linked list pointers
@@ -272,7 +272,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
             coreHash: coreHash_
         });
 
-        emit EntityCreated(key, msg.sender, entityHash_, op.expiresAt);
+        emit EntityCreated(key, msg.sender, op.expiresAt, entityHash_);
     }
 
     function _update(EntityHashing.Op calldata op, BlockNumber current) internal returns (bytes32, bytes32) {

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -52,14 +52,6 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     mapping(BlockNumber blockNumber => EntityHashing.BlockNode node) internal _blocks;
 
     // -------------------------------------------------------------------------
-    // Constants
-    // -------------------------------------------------------------------------
-
-    uint256 public constant MAX_PAYLOAD_SIZE = 24_576;
-    uint256 public constant MAX_ATTRIBUTES = 32;
-    uint256 public constant MAX_STRING_ATTR_SIZE = 1024;
-
-    // -------------------------------------------------------------------------
     // Events
     // -------------------------------------------------------------------------
 
@@ -67,10 +59,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         bytes32 indexed entityKey,
         address indexed owner,
         bytes32 entityHash,
-        BlockNumber expiresAt,
-        bytes payload,
-        string contentType,
-        EntityHashing.Attribute[] attributes
+        BlockNumber expiresAt
     );
 
     // -------------------------------------------------------------------------
@@ -216,17 +205,12 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     function _create(EntityHashing.Op calldata op, BlockNumber current) internal returns (bytes32 key, bytes32 entityHash_) {
         // TODO: contentType validation (e.g. non-empty, allowlist of MIME types).
 
-        // Validate payload size.
-        if (op.payload.length > MAX_PAYLOAD_SIZE) {
-            revert EntityHashing.PayloadTooLarge(op.payload.length, MAX_PAYLOAD_SIZE);
-        }
-
         // Validate attribute count.
-        if (op.attributes.length > MAX_ATTRIBUTES) {
-            revert EntityHashing.TooManyAttributes(op.attributes.length, MAX_ATTRIBUTES);
+        if (op.attributes.length > EntityHashing.MAX_ATTRIBUTES) {
+            revert EntityHashing.TooManyAttributes(op.attributes.length, EntityHashing.MAX_ATTRIBUTES);
         }
 
-        // Validate attributes: non-empty names, strict ascending order, string size limits.
+        // Validate attributes: non-empty names, strict ascending order, canonical encoding.
         for (uint256 i = 0; i < op.attributes.length; i++) {
             bytes32 name = ShortString.unwrap(op.attributes[i].name);
 
@@ -245,9 +229,9 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
                 if (op.attributes[i].fixedValue != bytes32(0)) {
                     revert EntityHashing.NonCanonicalAttribute(i);
                 }
-                if (bytes(op.attributes[i].stringValue).length > MAX_STRING_ATTR_SIZE) {
+                if (bytes(op.attributes[i].stringValue).length > EntityHashing.MAX_STRING_ATTR_SIZE) {
                     revert EntityHashing.StringAttributeTooLarge(
-                        name, bytes(op.attributes[i].stringValue).length, MAX_STRING_ATTR_SIZE
+                        name, bytes(op.attributes[i].stringValue).length, EntityHashing.MAX_STRING_ATTR_SIZE
                     );
                 }
             } else {
@@ -281,7 +265,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
             coreHash: coreHash_
         });
 
-        emit EntityCreated(key, msg.sender, entityHash_, op.expiresAt, op.payload, op.contentType, op.attributes);
+        emit EntityCreated(key, msg.sender, entityHash_, op.expiresAt);
     }
 
     function _update(EntityHashing.Op calldata op, BlockNumber current) internal returns (bytes32, bytes32) {

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -202,15 +202,42 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // Internal functions — entity operations
     // -------------------------------------------------------------------------
 
+    /// @dev Create a new entity. Validates inputs, mints a deterministic key
+    /// from the caller's nonce, computes the EIP-712 hash chain, and stores
+    /// a minimal on-chain commitment. Full entity data (payload, contentType,
+    /// attributes) remains in calldata — off-chain indexers reconstruct it
+    /// from the transaction, not from the event.
+    ///
+    /// Validation order:
+    ///   1. Attribute count (bounded by MAX_ATTRIBUTES)
+    ///   2. Per-attribute: non-empty name, strict ascending sort, canonical
+    ///      encoding (unused fields must be zero), string size limit
+    ///   3. Expiry must be strictly in the future
+    ///
+    /// Hash computation:
+    ///   coreHash  = EIP-712 hash of immutable content (key, creator, createdAt,
+    ///               contentType, payload, attributes)
+    ///   entityHash = EIP-712 domain-wrapped hash of (coreHash, owner, updatedAt,
+    ///                expiresAt)
+    ///
+    /// Storage: writes a Commitment struct (3 slots) keyed by entityKey.
+    /// Key uniqueness is guaranteed by the monotonic per-owner nonce —
+    /// no existence check is needed.
     function _create(EntityHashing.Op calldata op, BlockNumber current) internal returns (bytes32 key, bytes32 entityHash_) {
         // TODO: contentType validation (e.g. non-empty, allowlist of MIME types).
 
-        // Validate attribute count.
         if (op.attributes.length > EntityHashing.MAX_ATTRIBUTES) {
             revert EntityHashing.TooManyAttributes(op.attributes.length, EntityHashing.MAX_ATTRIBUTES);
         }
 
-        // Validate attributes: non-empty names, strict ascending order, canonical encoding.
+        // Validate each attribute:
+        //   - Name must be non-zero (ShortString with empty content is bytes32(0)).
+        //   - Names must be in strict ascending order by raw bytes32 value.
+        //     ShortString stores content from the MSB with length in the LSB,
+        //     so bytes32 comparison preserves lexicographic order for ASCII names.
+        //   - Canonical encoding: STRING attrs must have fixedValue == 0,
+        //     UINT/ENTITY_KEY attrs must have empty stringValue. This ensures
+        //     each attribute has exactly one encoding that produces a given hash.
         for (uint256 i = 0; i < op.attributes.length; i++) {
             bytes32 name = ShortString.unwrap(op.attributes[i].name);
 
@@ -241,21 +268,27 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
             }
         }
 
-        // Validate expiry.
+        // expiresAt must be strictly after the current block. Equality is
+        // rejected because the entity would already be expirable in this block.
         if (op.expiresAt <= current) {
             revert EntityHashing.ExpiryInPast(op.expiresAt, current);
         }
 
-        // Mint entity key from owner nonce.
+        // Derive a globally unique entity key: keccak256(chainId, registry, owner, nonce).
+        // The post-increment nonce guarantees uniqueness without an existence check.
         uint32 nonce = nonces[msg.sender]++;
         key = EntityHashing.entityKey(block.chainid, address(this), msg.sender, nonce);
 
-        // Compute hashes.
+        // Two-level EIP-712 hash:
+        //   coreHash: immutable content identity (survives transfers and expiry extensions)
+        //   entityHash: full entity state including mutable fields (owner, updatedAt, expiresAt)
         bytes32 coreHash_ =
             EntityHashing.coreHash(key, msg.sender, current, op.contentType, op.payload, op.attributes);
         entityHash_ = _entityHash(coreHash_, msg.sender, current, op.expiresAt);
 
-        // Store commitment (no payload/attributes — those live in calldata/events).
+        // Store the minimal on-chain commitment (3 slots). Payload and attributes
+        // are not stored — they live in calldata and are recoverable from the
+        // transaction. The coreHash commits to their content.
         _commitments[key] = EntityHashing.Commitment({
             creator: msg.sender,
             createdAt: current,

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -55,12 +55,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // Events
     // -------------------------------------------------------------------------
 
-    event EntityCreated(
-        bytes32 indexed entityKey,
-        address indexed owner,
-        bytes32 entityHash,
-        BlockNumber expiresAt
-    );
+    event EntityCreated(bytes32 indexed entityKey, address indexed owner, bytes32 entityHash, BlockNumber expiresAt);
 
     // -------------------------------------------------------------------------
     // State — linked list pointers
@@ -223,7 +218,10 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     /// Storage: writes a Commitment struct (3 slots) keyed by entityKey.
     /// Key uniqueness is guaranteed by the monotonic per-owner nonce —
     /// no existence check is needed.
-    function _create(EntityHashing.Op calldata op, BlockNumber current) internal returns (bytes32 key, bytes32 entityHash_) {
+    function _create(EntityHashing.Op calldata op, BlockNumber current)
+        internal
+        returns (bytes32 key, bytes32 entityHash_)
+    {
         // TODO: contentType validation (e.g. non-empty, allowlist of MIME types).
 
         if (op.attributes.length > EntityHashing.MAX_ATTRIBUTES) {
@@ -282,8 +280,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         // Two-level EIP-712 hash:
         //   coreHash: immutable content identity (survives transfers and expiry extensions)
         //   entityHash: full entity state including mutable fields (owner, updatedAt, expiresAt)
-        bytes32 coreHash_ =
-            EntityHashing.coreHash(key, msg.sender, current, op.contentType, op.payload, op.attributes);
+        bytes32 coreHash_ = EntityHashing.coreHash(key, msg.sender, current, op.contentType, op.payload, op.attributes);
         entityHash_ = _entityHash(coreHash_, msg.sender, current, op.expiresAt);
 
         // Store the minimal on-chain commitment (3 slots). Payload and attributes

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -220,7 +220,18 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         internal
         returns (bytes32 key, bytes32 entityHash_)
     {
-        // TODO: contentType validation (e.g. non-empty, allowlist of MIME types).
+        // TODO: contentType validation per RFC 6838 media type syntax.
+        //
+        // Format: type "/" subtype (no parameters)
+        //   - Exactly one "/" separator
+        //   - Each part: 1–127 chars
+        //   - First char: alphanumeric (a-z, A-Z, 0-9)
+        //   - Remaining chars: alphanumeric + ! # $ & - ^ _ . +
+        //   - Total length ≤ 255 bytes
+        //
+        // Implementation: 256-bit bitmap for valid charset, single pass over
+        // bytes(contentType). ~30 gas/byte — negligible for typical values
+        // like "application/json".
 
         if (op.attributes.length > EntityHashing.MAX_ATTRIBUTES) {
             revert EntityHashing.TooManyAttributes(op.attributes.length, EntityHashing.MAX_ATTRIBUTES);

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -240,10 +240,17 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
             }
 
             if (op.attributes[i].valueType == EntityHashing.AttributeType.STRING) {
+                if (op.attributes[i].fixedValue != bytes32(0)) {
+                    revert EntityHashing.NonCanonicalAttribute(i);
+                }
                 if (bytes(op.attributes[i].stringValue).length > MAX_STRING_ATTR_SIZE) {
                     revert EntityHashing.StringAttributeTooLarge(
                         name, bytes(op.attributes[i].stringValue).length, MAX_STRING_ATTR_SIZE
                     );
+                }
+            } else {
+                if (bytes(op.attributes[i].stringValue).length != 0) {
+                    revert EntityHashing.NonCanonicalAttribute(i);
                 }
             }
         }

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.24;
 
 import {BlockNumber, currentBlock} from "./BlockNumber.sol";
-import {ShortString} from "@openzeppelin/contracts/utils/ShortStrings.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import {EntityHashing, OpKey, TxKey} from "./EntityHashing.sol";
 
@@ -205,8 +204,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     ///
     /// Validation order:
     ///   1. Attribute count (bounded by MAX_ATTRIBUTES)
-    ///   2. Per-attribute: non-empty name, strict ascending sort, canonical
-    ///      encoding (unused fields must be zero), string size limit
+    ///   2. Per-attribute validation (sorting, value type/length) via coreHash → attributeHash
     ///   3. Expiry must be strictly in the future
     ///
     /// Hash computation:
@@ -227,44 +225,8 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         if (op.attributes.length > EntityHashing.MAX_ATTRIBUTES) {
             revert EntityHashing.TooManyAttributes(op.attributes.length, EntityHashing.MAX_ATTRIBUTES);
         }
-
-        // Validate each attribute:
-        //   - Name must be non-zero (ShortString with empty content is bytes32(0)).
-        //   - Names must be in strict ascending order by raw bytes32 value.
-        //     ShortString stores content from the MSB with length in the LSB,
-        //     so bytes32 comparison preserves lexicographic order for ASCII names.
-        //   - Canonical encoding: STRING attrs must have fixedValue == 0,
-        //     UINT/ENTITY_KEY attrs must have empty stringValue. This ensures
-        //     each attribute has exactly one encoding that produces a given hash.
-        for (uint256 i = 0; i < op.attributes.length; i++) {
-            bytes32 name = ShortString.unwrap(op.attributes[i].name);
-
-            if (name == bytes32(0)) {
-                revert EntityHashing.EmptyAttributeName(i);
-            }
-
-            if (i > 0) {
-                bytes32 prev = ShortString.unwrap(op.attributes[i - 1].name);
-                if (name <= prev) {
-                    revert EntityHashing.AttributesNotSorted(name, prev);
-                }
-            }
-
-            if (op.attributes[i].valueType == EntityHashing.AttributeType.STRING) {
-                if (op.attributes[i].fixedValue != bytes32(0)) {
-                    revert EntityHashing.NonCanonicalAttribute(i);
-                }
-                if (bytes(op.attributes[i].stringValue).length > EntityHashing.MAX_STRING_ATTR_SIZE) {
-                    revert EntityHashing.StringAttributeTooLarge(
-                        name, bytes(op.attributes[i].stringValue).length, EntityHashing.MAX_STRING_ATTR_SIZE
-                    );
-                }
-            } else {
-                if (bytes(op.attributes[i].stringValue).length != 0) {
-                    revert EntityHashing.NonCanonicalAttribute(i);
-                }
-            }
-        }
+        // Per-attribute validation (sorting, value type/length) is handled
+        // inside coreHash → attributeHash.
 
         // expiresAt must be strictly after the current block. Equality is
         // rejected because the entity would already be expirable in this block.

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {BlockNumber, currentBlock} from "./BlockNumber.sol";
+import {ShortString} from "@openzeppelin/contracts/utils/ShortStrings.sol";
 import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
 import {EntityHashing, OpKey, TxKey} from "./EntityHashing.sol";
 
@@ -21,6 +22,12 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // -------------------------------------------------------------------------
 
     mapping(address owner => uint32) public nonces;
+
+    /// @dev Entity commitment map: entityKey → Commitment.
+    /// Stores only the fields needed to recompute entityHash from chain
+    /// state alone. Full entity data (payload, attributes) lives in
+    /// calldata/events for the off-chain DB.
+    mapping(bytes32 entityKey => EntityHashing.Commitment) internal _commitments;
 
     // Three-level changeset hash lookup table.
     //
@@ -43,6 +50,32 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // Block-level linked list: only blocks with mutations have entries.
     // Enables O(1) traversal across sparse blocks.
     mapping(BlockNumber blockNumber => EntityHashing.BlockNode node) internal _blocks;
+
+    // -------------------------------------------------------------------------
+    // Constants
+    // -------------------------------------------------------------------------
+
+    uint256 public constant MAX_PAYLOAD_SIZE = 24_576;
+    uint256 public constant MAX_ATTRIBUTES = 32;
+    uint256 public constant MAX_STRING_ATTR_SIZE = 1024;
+
+    // -------------------------------------------------------------------------
+    // Events
+    // -------------------------------------------------------------------------
+
+    event EntityCreated(
+        bytes32 indexed entityKey,
+        address indexed owner,
+        bytes32 entityHash,
+        BlockNumber expiresAt,
+        bytes payload,
+        string contentType,
+        EntityHashing.Attribute[] attributes
+    );
+
+    // -------------------------------------------------------------------------
+    // State — linked list pointers
+    // -------------------------------------------------------------------------
 
     BlockNumber internal immutable _genesisBlock;
 
@@ -157,6 +190,10 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         return _txOpCount[EntityHashing.txKey(blockNumber, txSeq)];
     }
 
+    function getCommitment(bytes32 key) public view returns (EntityHashing.Commitment memory) {
+        return _commitments[key];
+    }
+
     // -------------------------------------------------------------------------
     // Internal functions — entity hash (requires domain separator)
     // -------------------------------------------------------------------------
@@ -173,13 +210,76 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     }
 
     // -------------------------------------------------------------------------
-    // Internal functions — entity operations (skeletons)
+    // Internal functions — entity operations
     // -------------------------------------------------------------------------
 
     function _create(EntityHashing.Op calldata op) internal returns (bytes32 key, bytes32 entityHash_) {
-        // Validates: content type allowlist, payload size, attribute constraints (sorted, no empty names, unused fields zeroed)
-        // Then: mint key via nonce, compute coreHash + entityHash, store entity, expiresAt must be in future
-        revert("not implemented");
+        // Validate payload size.
+        if (op.payload.length > MAX_PAYLOAD_SIZE) {
+            revert EntityHashing.PayloadTooLarge(op.payload.length, MAX_PAYLOAD_SIZE);
+        }
+
+        // Validate attribute count.
+        if (op.attributes.length > MAX_ATTRIBUTES) {
+            revert EntityHashing.TooManyAttributes(op.attributes.length, MAX_ATTRIBUTES);
+        }
+
+        // Validate attributes: non-empty names, strict ascending order, string size limits.
+        for (uint256 i = 0; i < op.attributes.length; i++) {
+            bytes32 name = ShortString.unwrap(op.attributes[i].name);
+
+            if (name == bytes32(0)) {
+                revert EntityHashing.EmptyAttributeName(i);
+            }
+
+            if (i > 0) {
+                bytes32 prev = ShortString.unwrap(op.attributes[i - 1].name);
+                if (name <= prev) {
+                    revert EntityHashing.AttributesNotSorted(name, prev);
+                }
+            }
+
+            if (op.attributes[i].valueType == EntityHashing.AttributeType.STRING) {
+                if (bytes(op.attributes[i].stringValue).length > MAX_STRING_ATTR_SIZE) {
+                    revert EntityHashing.StringAttributeTooLarge(
+                        name, bytes(op.attributes[i].stringValue).length, MAX_STRING_ATTR_SIZE
+                    );
+                }
+            }
+        }
+
+        // Validate expiry.
+        BlockNumber now_ = currentBlock();
+        if (op.expiresAt <= now_) {
+            revert EntityHashing.ExpiryInPast(op.expiresAt, now_);
+        }
+
+        // Mint entity key from owner nonce.
+        uint32 nonce = nonces[msg.sender]++;
+        key = EntityHashing.entityKey(block.chainid, address(this), msg.sender, nonce);
+
+        // Entity key must not already exist (nonce should guarantee this,
+        // but defensive check against storage collision).
+        if (_commitments[key].createdAt != BlockNumber.wrap(0)) {
+            revert EntityHashing.EntityAlreadyExists(key);
+        }
+
+        // Compute hashes.
+        bytes32 coreHash_ =
+            EntityHashing.coreHash(key, msg.sender, now_, op.contentType, op.payload, op.attributes);
+        entityHash_ = _entityHash(coreHash_, msg.sender, now_, op.expiresAt);
+
+        // Store commitment (no payload/attributes — those live in calldata/events).
+        _commitments[key] = EntityHashing.Commitment({
+            creator: msg.sender,
+            createdAt: now_,
+            updatedAt: now_,
+            expiresAt: op.expiresAt,
+            owner: msg.sender,
+            coreHash: coreHash_
+        });
+
+        emit EntityCreated(key, msg.sender, entityHash_, op.expiresAt, op.payload, op.contentType, op.attributes);
     }
 
     function _update(EntityHashing.Op calldata op) internal returns (bytes32, bytes32) {

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -260,7 +260,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
 
         // Entity key must not already exist (nonce should guarantee this,
         // but defensive check against storage collision).
-        if (_commitments[key].createdAt != BlockNumber.wrap(0)) {
+        if (_commitments[key].creator != address(0)) {
             revert EntityHashing.EntityAlreadyExists(key);
         }
 

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -129,17 +129,17 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
             bytes32 entityHash_;
 
             if (opType == EntityHashing.CREATE) {
-                (key, entityHash_) = _create(ops[opSeq]);
+                (key, entityHash_) = _create(ops[opSeq], current);
             } else if (opType == EntityHashing.UPDATE) {
-                (key, entityHash_) = _update(ops[opSeq]);
+                (key, entityHash_) = _update(ops[opSeq], current);
             } else if (opType == EntityHashing.EXTEND) {
-                (key, entityHash_) = _extend(ops[opSeq]);
+                (key, entityHash_) = _extend(ops[opSeq], current);
             } else if (opType == EntityHashing.TRANSFER) {
-                (key, entityHash_) = _transfer(ops[opSeq]);
+                (key, entityHash_) = _transfer(ops[opSeq], current);
             } else if (opType == EntityHashing.DELETE) {
-                (key, entityHash_) = _delete(ops[opSeq]);
+                (key, entityHash_) = _delete(ops[opSeq], current);
             } else if (opType == EntityHashing.EXPIRE) {
-                (key, entityHash_) = _expire(ops[opSeq].entityKey);
+                (key, entityHash_) = _expire(ops[opSeq].entityKey, current);
             } else {
                 // TODO should not reach here
             }
@@ -213,7 +213,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // Internal functions — entity operations
     // -------------------------------------------------------------------------
 
-    function _create(EntityHashing.Op calldata op) internal returns (bytes32 key, bytes32 entityHash_) {
+    function _create(EntityHashing.Op calldata op, BlockNumber current) internal returns (bytes32 key, bytes32 entityHash_) {
         // Validate payload size.
         if (op.payload.length > MAX_PAYLOAD_SIZE) {
             revert EntityHashing.PayloadTooLarge(op.payload.length, MAX_PAYLOAD_SIZE);
@@ -256,9 +256,8 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         }
 
         // Validate expiry.
-        BlockNumber now_ = currentBlock();
-        if (op.expiresAt <= now_) {
-            revert EntityHashing.ExpiryInPast(op.expiresAt, now_);
+        if (op.expiresAt <= current) {
+            revert EntityHashing.ExpiryInPast(op.expiresAt, current);
         }
 
         // Mint entity key from owner nonce.
@@ -273,14 +272,14 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
 
         // Compute hashes.
         bytes32 coreHash_ =
-            EntityHashing.coreHash(key, msg.sender, now_, op.contentType, op.payload, op.attributes);
-        entityHash_ = _entityHash(coreHash_, msg.sender, now_, op.expiresAt);
+            EntityHashing.coreHash(key, msg.sender, current, op.contentType, op.payload, op.attributes);
+        entityHash_ = _entityHash(coreHash_, msg.sender, current, op.expiresAt);
 
         // Store commitment (no payload/attributes — those live in calldata/events).
         _commitments[key] = EntityHashing.Commitment({
             creator: msg.sender,
-            createdAt: now_,
-            updatedAt: now_,
+            createdAt: current,
+            updatedAt: current,
             expiresAt: op.expiresAt,
             owner: msg.sender,
             coreHash: coreHash_
@@ -289,31 +288,31 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         emit EntityCreated(key, msg.sender, entityHash_, op.expiresAt, op.payload, op.contentType, op.attributes);
     }
 
-    function _update(EntityHashing.Op calldata op) internal returns (bytes32, bytes32) {
+    function _update(EntityHashing.Op calldata op, BlockNumber current) internal returns (bytes32, bytes32) {
         // Validates: entity exists + not expired + msg.sender is owner, content type, payload, attributes (same as create)
         // Then: recompute coreHash from new content, update entity, recompute entityHash
         revert("not implemented");
     }
 
-    function _extend(EntityHashing.Op calldata op) internal returns (bytes32, bytes32) {
+    function _extend(EntityHashing.Op calldata op, BlockNumber current) internal returns (bytes32, bytes32) {
         // Validates: entity exists + not expired + msg.sender is owner, new expiresAt > current expiresAt
         // Then: update expiresAt + updatedAt, recompute entityHash from stored coreHash
         revert("not implemented");
     }
 
-    function _transfer(EntityHashing.Op calldata op) internal returns (bytes32, bytes32) {
+    function _transfer(EntityHashing.Op calldata op, BlockNumber current) internal returns (bytes32, bytes32) {
         // Validates: entity exists + not expired + msg.sender is owner, newOwner != address(0)
         // Then: set owner to newOwner + updatedAt, recompute entityHash from stored coreHash
         revert("not implemented");
     }
 
-    function _delete(EntityHashing.Op calldata op) internal returns (bytes32, bytes32) {
+    function _delete(EntityHashing.Op calldata op, BlockNumber current) internal returns (bytes32, bytes32) {
         // Validates: entity exists + not expired + msg.sender is owner
         // Then: snapshot entityHash before deletion, delete entity
         revert("not implemented");
     }
 
-    function _expire(bytes32 key) internal returns (bytes32, bytes32) {
+    function _expire(bytes32 key, BlockNumber current) internal returns (bytes32, bytes32) {
         // Validates: entity exists + currentBlock >= expiresAt (entity has expired)
         // Then: snapshot entityHash before deletion, delete entity (callable by anyone)
         revert("not implemented");

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -214,6 +214,8 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // -------------------------------------------------------------------------
 
     function _create(EntityHashing.Op calldata op, BlockNumber current) internal returns (bytes32 key, bytes32 entityHash_) {
+        // TODO: contentType validation (e.g. non-empty, allowlist of MIME types).
+
         // Validate payload size.
         if (op.payload.length > MAX_PAYLOAD_SIZE) {
             revert EntityHashing.PayloadTooLarge(op.payload.length, MAX_PAYLOAD_SIZE);

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -264,12 +264,6 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         uint32 nonce = nonces[msg.sender]++;
         key = EntityHashing.entityKey(block.chainid, address(this), msg.sender, nonce);
 
-        // Entity key must not already exist (nonce should guarantee this,
-        // but defensive check against storage collision).
-        if (_commitments[key].creator != address(0)) {
-            revert EntityHashing.EntityAlreadyExists(key);
-        }
-
         // Compute hashes.
         bytes32 coreHash_ =
             EntityHashing.coreHash(key, msg.sender, current, op.contentType, op.payload, op.attributes);

--- a/test/unit/ops/Create.t.sol
+++ b/test/unit/ops/Create.t.sol
@@ -1,0 +1,413 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {BlockNumber, currentBlock} from "../../../src/BlockNumber.sol";
+import {ShortStrings, ShortString} from "@openzeppelin/contracts/utils/ShortStrings.sol";
+import {Base} from "../../utils/Base.t.sol";
+import {Lib} from "../../utils/Lib.sol";
+import {EntityHashing} from "../../../src/EntityHashing.sol";
+
+contract CreateTest is Base {
+    using ShortStrings for *;
+
+    BlockNumber expiresAt;
+
+    function setUp() public override {
+        super.setUp();
+        // Default expiry: current block + 1000
+        expiresAt = currentBlock() + BlockNumber.wrap(1000);
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    function _defaultOp() internal view returns (EntityHashing.Op memory) {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        return Lib.createOp("hello", "text/plain", attrs, expiresAt);
+    }
+
+    function _defaultOpWithAttrs(EntityHashing.Attribute[] memory attrs)
+        internal
+        view
+        returns (EntityHashing.Op memory)
+    {
+        return Lib.createOp("hello", "text/plain", attrs, expiresAt);
+    }
+
+    // =========================================================================
+    // Validation — attribute count
+    // =========================================================================
+
+    function test_create_tooManyAttributes_reverts() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](33);
+        for (uint256 i = 0; i < 33; i++) {
+            // Each name must be unique and sorted — use single-char ascending
+            bytes memory name = new bytes(1);
+            name[0] = bytes1(uint8(0x41 + i)); // A, B, C, ...
+            attrs[i] = Lib.uintAttr(string(name), i);
+        }
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.TooManyAttributes.selector, 33, 32));
+        registry.exposed_create(op);
+    }
+
+    function test_create_maxAttributes_succeeds() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](32);
+        for (uint256 i = 0; i < 32; i++) {
+            bytes memory name = new bytes(1);
+            name[0] = bytes1(uint8(0x41 + i));
+            attrs[i] = Lib.uintAttr(string(name), i);
+        }
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        (bytes32 key,) = registry.exposed_create(op);
+        assertTrue(key != bytes32(0));
+    }
+
+    // =========================================================================
+    // Validation — empty attribute name
+    // =========================================================================
+
+    function test_create_emptyAttributeName_reverts() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
+        attrs[0] = EntityHashing.Attribute({
+            name: ShortString.wrap(bytes32(0)),
+            valueType: EntityHashing.AttributeType.UINT,
+            fixedValue: bytes32(uint256(1)),
+            stringValue: ""
+        });
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EmptyAttributeName.selector, 0));
+        registry.exposed_create(op);
+    }
+
+    // =========================================================================
+    // Validation — attribute sort order
+    // =========================================================================
+
+    function test_create_duplicateAttributeNames_reverts() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](2);
+        attrs[0] = Lib.uintAttr("aaa", 1);
+        attrs[1] = Lib.uintAttr("aaa", 2);
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        vm.expectRevert(); // AttributesNotSorted
+        registry.exposed_create(op);
+    }
+
+    function test_create_unsortedAttributes_reverts() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](2);
+        attrs[0] = Lib.uintAttr("bbb", 1);
+        attrs[1] = Lib.uintAttr("aaa", 2);
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        vm.expectRevert(); // AttributesNotSorted
+        registry.exposed_create(op);
+    }
+
+    function test_create_sortedAttributes_succeeds() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](2);
+        attrs[0] = Lib.uintAttr("aaa", 1);
+        attrs[1] = Lib.uintAttr("bbb", 2);
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        (bytes32 key,) = registry.exposed_create(op);
+        assertTrue(key != bytes32(0));
+    }
+
+    // =========================================================================
+    // Validation — canonical encoding
+    // =========================================================================
+
+    function test_create_stringAttr_nonZeroFixedValue_reverts() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
+        attrs[0] = EntityHashing.Attribute({
+            name: "aaa".toShortString(),
+            valueType: EntityHashing.AttributeType.STRING,
+            fixedValue: bytes32(uint256(1)),
+            stringValue: "hello"
+        });
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NonCanonicalAttribute.selector, 0));
+        registry.exposed_create(op);
+    }
+
+    function test_create_uintAttr_nonEmptyStringValue_reverts() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
+        attrs[0] = EntityHashing.Attribute({
+            name: "aaa".toShortString(),
+            valueType: EntityHashing.AttributeType.UINT,
+            fixedValue: bytes32(uint256(42)),
+            stringValue: "should be empty"
+        });
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NonCanonicalAttribute.selector, 0));
+        registry.exposed_create(op);
+    }
+
+    function test_create_entityKeyAttr_nonEmptyStringValue_reverts() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
+        attrs[0] = EntityHashing.Attribute({
+            name: "aaa".toShortString(),
+            valueType: EntityHashing.AttributeType.ENTITY_KEY,
+            fixedValue: keccak256("key"),
+            stringValue: "should be empty"
+        });
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NonCanonicalAttribute.selector, 0));
+        registry.exposed_create(op);
+    }
+
+    // =========================================================================
+    // Validation — string attribute size
+    // =========================================================================
+
+    function test_create_stringAttrTooLarge_reverts() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
+        bytes memory largeString = new bytes(1025);
+        attrs[0] = EntityHashing.Attribute({
+            name: "aaa".toShortString(),
+            valueType: EntityHashing.AttributeType.STRING,
+            fixedValue: bytes32(0),
+            stringValue: string(largeString)
+        });
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        vm.expectRevert(); // StringAttributeTooLarge
+        registry.exposed_create(op);
+    }
+
+    function test_create_stringAttrAtMaxSize_succeeds() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
+        bytes memory maxString = new bytes(1024);
+        attrs[0] = EntityHashing.Attribute({
+            name: "aaa".toShortString(),
+            valueType: EntityHashing.AttributeType.STRING,
+            fixedValue: bytes32(0),
+            stringValue: string(maxString)
+        });
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        (bytes32 key,) = registry.exposed_create(op);
+        assertTrue(key != bytes32(0));
+    }
+
+    // =========================================================================
+    // Validation — expiry
+    // =========================================================================
+
+    function test_create_expiryEqualToCurrentBlock_reverts() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory op = Lib.createOp("hello", "text/plain", attrs, currentBlock());
+
+        vm.prank(alice);
+        vm.expectRevert(); // ExpiryInPast
+        registry.exposed_create(op);
+    }
+
+    function test_create_expiryInPast_reverts() public {
+        // Roll forward so we can set expiry in the past
+        vm.roll(block.number + 100);
+
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory op = Lib.createOp("hello", "text/plain", attrs, BlockNumber.wrap(1));
+
+        vm.prank(alice);
+        vm.expectRevert(); // ExpiryInPast
+        registry.exposed_create(op);
+    }
+
+    function test_create_expiryOneBlockAhead_succeeds() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory op = Lib.createOp("hello", "text/plain", attrs, currentBlock() + BlockNumber.wrap(1));
+
+        vm.prank(alice);
+        (bytes32 key,) = registry.exposed_create(op);
+        assertTrue(key != bytes32(0));
+    }
+
+    // =========================================================================
+    // State — commitment
+    // =========================================================================
+
+    function test_create_storesCommitment() public {
+        EntityHashing.Op memory op = _defaultOp();
+
+        vm.prank(alice);
+        (bytes32 key,) = registry.exposed_create(op);
+
+        EntityHashing.Commitment memory c = registry.getCommitment(key);
+        assertEq(c.creator, alice);
+        assertEq(c.owner, alice);
+        assertEq(BlockNumber.unwrap(c.createdAt), uint32(block.number));
+        assertEq(BlockNumber.unwrap(c.updatedAt), uint32(block.number));
+        assertEq(BlockNumber.unwrap(c.expiresAt), BlockNumber.unwrap(expiresAt));
+        assertTrue(c.coreHash != bytes32(0));
+    }
+
+    // =========================================================================
+    // State — nonce
+    // =========================================================================
+
+    function test_create_incrementsNonce() public {
+        assertEq(registry.nonces(alice), 0);
+
+        EntityHashing.Op memory op = _defaultOp();
+
+        vm.prank(alice);
+        registry.exposed_create(op);
+        assertEq(registry.nonces(alice), 1);
+
+        vm.prank(alice);
+        registry.exposed_create(op);
+        assertEq(registry.nonces(alice), 2);
+    }
+
+    function test_create_independentNoncesPerSender() public {
+        EntityHashing.Op memory op = _defaultOp();
+
+        vm.prank(alice);
+        registry.exposed_create(op);
+
+        vm.prank(bob);
+        registry.exposed_create(op);
+
+        assertEq(registry.nonces(alice), 1);
+        assertEq(registry.nonces(bob), 1);
+    }
+
+    // =========================================================================
+    // State — entity key determinism
+    // =========================================================================
+
+    function test_create_keyMatchesEntityKeyFunction() public {
+        // Pre-compute expected key at nonce 0
+        bytes32 expectedKey = registry.entityKey(alice, 0);
+
+        EntityHashing.Op memory op = _defaultOp();
+        vm.prank(alice);
+        (bytes32 key,) = registry.exposed_create(op);
+
+        assertEq(key, expectedKey);
+    }
+
+    function test_create_secondKeyMatchesNonce1() public {
+        EntityHashing.Op memory op = _defaultOp();
+
+        vm.prank(alice);
+        registry.exposed_create(op);
+
+        bytes32 expectedKey = registry.entityKey(alice, 1);
+        vm.prank(alice);
+        (bytes32 key,) = registry.exposed_create(op);
+
+        assertEq(key, expectedKey);
+    }
+
+    function test_create_differentSenders_differentKeys() public {
+        EntityHashing.Op memory op = _defaultOp();
+
+        vm.prank(alice);
+        (bytes32 keyAlice,) = registry.exposed_create(op);
+
+        vm.prank(bob);
+        (bytes32 keyBob,) = registry.exposed_create(op);
+
+        assertNotEq(keyAlice, keyBob);
+    }
+
+    // =========================================================================
+    // Event
+    // =========================================================================
+
+    function test_create_emitsEntityCreated() public {
+        EntityHashing.Op memory op = _defaultOp();
+        bytes32 expectedKey = registry.entityKey(alice, 0);
+
+        vm.prank(alice);
+        vm.expectEmit(true, true, false, false);
+        emit EntityCreated(expectedKey, alice, bytes32(0), expiresAt);
+        registry.exposed_create(op);
+    }
+
+    // Redeclare event for vm.expectEmit matching
+    event EntityCreated(bytes32 indexed entityKey, address indexed owner, bytes32 entityHash, BlockNumber expiresAt);
+
+    // =========================================================================
+    // Hash correctness
+    // =========================================================================
+
+    function test_create_coreHashMatchesManualComputation() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
+        attrs[0] = Lib.uintAttr("count", 42);
+        EntityHashing.Op memory op = Lib.createOp("hello", "text/plain", attrs, expiresAt);
+
+        vm.prank(alice);
+        (bytes32 key,) = registry.exposed_create(op);
+
+        EntityHashing.Commitment memory c = registry.getCommitment(key);
+
+        // Manually compute coreHash
+        bytes32 expected = registry.exposed_coreHash(key, alice, c.createdAt, "text/plain", "hello", attrs);
+        assertEq(c.coreHash, expected);
+    }
+
+    function test_create_entityHashMatchesManualComputation() public {
+        EntityHashing.Op memory op = _defaultOp();
+
+        vm.prank(alice);
+        (bytes32 key, bytes32 entityHash_) = registry.exposed_create(op);
+
+        EntityHashing.Commitment memory c = registry.getCommitment(key);
+
+        bytes32 expected = registry.exposed_entityHash(c.coreHash, alice, c.updatedAt, c.expiresAt);
+        assertEq(entityHash_, expected);
+    }
+
+    // =========================================================================
+    // Edge cases
+    // =========================================================================
+
+    function test_create_emptyPayloadAndAttributes() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory op = Lib.createOp("", "text/plain", attrs, expiresAt);
+
+        vm.prank(alice);
+        (bytes32 key, bytes32 entityHash_) = registry.exposed_create(op);
+
+        assertTrue(key != bytes32(0));
+        assertTrue(entityHash_ != bytes32(0));
+    }
+
+    function test_create_allThreeAttributeTypes() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](3);
+        attrs[0] = Lib.entityKeyAttr("aaa", keccak256("ref"));
+        attrs[1] = Lib.stringAttr("bbb", "value");
+        attrs[2] = Lib.uintAttr("ccc", 99);
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+
+        vm.prank(alice);
+        (bytes32 key,) = registry.exposed_create(op);
+
+        EntityHashing.Commitment memory c = registry.getCommitment(key);
+        assertTrue(c.coreHash != bytes32(0));
+    }
+}

--- a/test/unit/ops/Create.t.sol
+++ b/test/unit/ops/Create.t.sol
@@ -297,11 +297,11 @@ contract CreateTest is Base {
 
         vm.prank(alice);
         vm.expectEmit(true, true, false, false);
-        emit EntityCreated(expectedKey, alice, bytes32(0), expiresAt);
+        emit EntityCreated(expectedKey, alice, expiresAt, bytes32(0));
         registry.exposed_create(op);
     }
 
-    event EntityCreated(bytes32 indexed entityKey, address indexed owner, bytes32 entityHash, BlockNumber expiresAt);
+    event EntityCreated(bytes32 indexed entityKey, address indexed owner, BlockNumber expiresAt, bytes32 entityHash);
 
     // =========================================================================
     // Hash correctness

--- a/test/unit/ops/Create.t.sol
+++ b/test/unit/ops/Create.t.sol
@@ -2,19 +2,15 @@
 pragma solidity ^0.8.24;
 
 import {BlockNumber, currentBlock} from "../../../src/BlockNumber.sol";
-import {ShortStrings, ShortString} from "@openzeppelin/contracts/utils/ShortStrings.sol";
 import {Base} from "../../utils/Base.t.sol";
 import {Lib} from "../../utils/Lib.sol";
 import {EntityHashing} from "../../../src/EntityHashing.sol";
 
 contract CreateTest is Base {
-    using ShortStrings for *;
-
     BlockNumber expiresAt;
 
     function setUp() public override {
         super.setUp();
-        // Default expiry: current block + 1000
         expiresAt = currentBlock() + BlockNumber.wrap(1000);
     }
 
@@ -42,9 +38,8 @@ contract CreateTest is Base {
     function test_create_tooManyAttributes_reverts() public {
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](33);
         for (uint256 i = 0; i < 33; i++) {
-            // Each name must be unique and sorted — use single-char ascending
             bytes memory name = new bytes(1);
-            name[0] = bytes1(uint8(0x41 + i)); // A, B, C, ...
+            name[0] = bytes1(uint8(0x41 + i));
             attrs[i] = Lib.uintAttr(string(name), i);
         }
 
@@ -75,15 +70,12 @@ contract CreateTest is Base {
     function test_create_emptyAttributeName_reverts() public {
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
         attrs[0] = EntityHashing.Attribute({
-            name: ShortString.wrap(bytes32(0)),
-            valueType: EntityHashing.AttributeType.UINT,
-            fixedValue: bytes32(uint256(1)),
-            stringValue: ""
+            name: bytes32(0), valueType: EntityHashing.ATTR_UINT, value: abi.encode(uint256(1))
         });
 
         EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
         vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EmptyAttributeName.selector, 0));
+        vm.expectRevert(EntityHashing.AttributesNotSorted.selector);
         registry.exposed_create(op);
     }
 
@@ -98,7 +90,7 @@ contract CreateTest is Base {
 
         EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
         vm.prank(alice);
-        vm.expectRevert(); // AttributesNotSorted
+        vm.expectRevert(EntityHashing.AttributesNotSorted.selector);
         registry.exposed_create(op);
     }
 
@@ -109,7 +101,7 @@ contract CreateTest is Base {
 
         EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
         vm.prank(alice);
-        vm.expectRevert(); // AttributesNotSorted
+        vm.expectRevert(EntityHashing.AttributesNotSorted.selector);
         registry.exposed_create(op);
     }
 
@@ -125,88 +117,52 @@ contract CreateTest is Base {
     }
 
     // =========================================================================
-    // Validation — canonical encoding
-    // =========================================================================
-
-    function test_create_stringAttr_nonZeroFixedValue_reverts() public {
-        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
-        attrs[0] = EntityHashing.Attribute({
-            name: "aaa".toShortString(),
-            valueType: EntityHashing.AttributeType.STRING,
-            fixedValue: bytes32(uint256(1)),
-            stringValue: "hello"
-        });
-
-        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NonCanonicalAttribute.selector, 0));
-        registry.exposed_create(op);
-    }
-
-    function test_create_uintAttr_nonEmptyStringValue_reverts() public {
-        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
-        attrs[0] = EntityHashing.Attribute({
-            name: "aaa".toShortString(),
-            valueType: EntityHashing.AttributeType.UINT,
-            fixedValue: bytes32(uint256(42)),
-            stringValue: "should be empty"
-        });
-
-        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NonCanonicalAttribute.selector, 0));
-        registry.exposed_create(op);
-    }
-
-    function test_create_entityKeyAttr_nonEmptyStringValue_reverts() public {
-        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
-        attrs[0] = EntityHashing.Attribute({
-            name: "aaa".toShortString(),
-            valueType: EntityHashing.AttributeType.ENTITY_KEY,
-            fixedValue: keccak256("key"),
-            stringValue: "should be empty"
-        });
-
-        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NonCanonicalAttribute.selector, 0));
-        registry.exposed_create(op);
-    }
-
-    // =========================================================================
-    // Validation — string attribute size
+    // Validation — value type/length (via attributeHash)
     // =========================================================================
 
     function test_create_stringAttrTooLarge_reverts() public {
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
-        bytes memory largeString = new bytes(1025);
         attrs[0] = EntityHashing.Attribute({
-            name: "aaa".toShortString(),
-            valueType: EntityHashing.AttributeType.STRING,
-            fixedValue: bytes32(0),
-            stringValue: string(largeString)
+            name: Lib.packName("aaa"), valueType: EntityHashing.ATTR_STRING, value: new bytes(1025)
         });
 
         EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
         vm.prank(alice);
-        vm.expectRevert(); // StringAttributeTooLarge
+        vm.expectRevert(); // InvalidValueLength
         registry.exposed_create(op);
     }
 
     function test_create_stringAttrAtMaxSize_succeeds() public {
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
-        bytes memory maxString = new bytes(1024);
         attrs[0] = EntityHashing.Attribute({
-            name: "aaa".toShortString(),
-            valueType: EntityHashing.AttributeType.STRING,
-            fixedValue: bytes32(0),
-            stringValue: string(maxString)
+            name: Lib.packName("aaa"), valueType: EntityHashing.ATTR_STRING, value: new bytes(1024)
         });
 
         EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
         vm.prank(alice);
         (bytes32 key,) = registry.exposed_create(op);
         assertTrue(key != bytes32(0));
+    }
+
+    function test_create_uintAttrWrongLength_reverts() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
+        attrs[0] =
+            EntityHashing.Attribute({name: Lib.packName("aaa"), valueType: EntityHashing.ATTR_UINT, value: hex"01"});
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        vm.expectRevert(); // InvalidValueLength
+        registry.exposed_create(op);
+    }
+
+    function test_create_invalidValueType_reverts() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
+        attrs[0] = EntityHashing.Attribute({name: Lib.packName("aaa"), valueType: 99, value: hex"00"});
+
+        EntityHashing.Op memory op = _defaultOpWithAttrs(attrs);
+        vm.prank(alice);
+        vm.expectRevert(); // InvalidValueType
+        registry.exposed_create(op);
     }
 
     // =========================================================================
@@ -223,7 +179,6 @@ contract CreateTest is Base {
     }
 
     function test_create_expiryInPast_reverts() public {
-        // Roll forward so we can set expiry in the past
         vm.roll(block.number + 100);
 
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
@@ -298,7 +253,6 @@ contract CreateTest is Base {
     // =========================================================================
 
     function test_create_keyMatchesEntityKeyFunction() public {
-        // Pre-compute expected key at nonce 0
         bytes32 expectedKey = registry.entityKey(alice, 0);
 
         EntityHashing.Op memory op = _defaultOp();
@@ -347,7 +301,6 @@ contract CreateTest is Base {
         registry.exposed_create(op);
     }
 
-    // Redeclare event for vm.expectEmit matching
     event EntityCreated(bytes32 indexed entityKey, address indexed owner, bytes32 entityHash, BlockNumber expiresAt);
 
     // =========================================================================
@@ -364,7 +317,6 @@ contract CreateTest is Base {
 
         EntityHashing.Commitment memory c = registry.getCommitment(key);
 
-        // Manually compute coreHash
         bytes32 expected = registry.exposed_coreHash(key, alice, c.createdAt, "text/plain", "hello", attrs);
         assertEq(c.coreHash, expected);
     }

--- a/test/utils/EntityRegistryHarness.sol
+++ b/test/utils/EntityRegistryHarness.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
-import {BlockNumber} from "../../src/BlockNumber.sol";
+import {BlockNumber, currentBlock} from "../../src/BlockNumber.sol";
 import {EntityRegistry} from "../../src/EntityRegistry.sol";
 import {EntityHashing} from "../../src/EntityHashing.sol";
 
@@ -31,5 +31,9 @@ contract EntityRegistryHarness is EntityRegistry {
         returns (bytes32)
     {
         return _entityHash(coreHash_, owner, updatedAt, expiresAt);
+    }
+
+    function exposed_create(EntityHashing.Op calldata op) external returns (bytes32 key, bytes32 entityHash_) {
+        return _create(op, currentBlock());
     }
 }

--- a/test/utils/Lib.sol
+++ b/test/utils/Lib.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+import {BlockNumber} from "../../src/BlockNumber.sol";
 import {EntityHashing} from "../../src/EntityHashing.sol";
 
 library Lib {
@@ -11,6 +12,23 @@ library Lib {
         assembly {
             result := mload(add(b, 32))
         }
+    }
+
+    function createOp(
+        bytes memory payload_,
+        string memory contentType_,
+        EntityHashing.Attribute[] memory attributes_,
+        BlockNumber expiresAt_
+    ) internal pure returns (EntityHashing.Op memory) {
+        return EntityHashing.Op({
+            opType: EntityHashing.CREATE,
+            entityKey: bytes32(0),
+            payload: payload_,
+            contentType: contentType_,
+            attributes: attributes_,
+            expiresAt: expiresAt_,
+            newOwner: address(0)
+        });
     }
 
     function uintAttr(string memory name, uint256 value) internal pure returns (EntityHashing.Attribute memory) {


### PR DESCRIPTION
 - **`_create` implementation**: Validates attributes (count, sort order, canonical encoding, string size), expiry, mints a deterministic entity key from a monotonic per-owner nonce, computes the two-level EIP-712 hash (coreHash + entityHash), and stores a 3-slot on-chain Commitment. Full entity data (payload, contentType, attributes) remains in calldata — not emitted in the event.
- **Existence check uses `creator != address(0)`** instead of `createdAt != 0` — `msg.sender` is guaranteed non-zero, no block number assumptions needed.
- **Canonical attribute encoding enforced**: STRING attributes must have `fixedValue == 0`, UINT/ENTITY_KEY must have empty `stringValue`. Prevents multiple encodings producing different hashes for semantically identical attributes.
- **`currentBlock()` threaded as parameter**: `execute()` calls `currentBlock()` once and passes it to all op functions, avoiding redundant derivation.
- **Removed `EntityAlreadyExists` check**: nonce monotonicity guarantees key uniqueness — the SLOAD was unreachable dead code.
- **Slimmed `EntityCreated` event**: removed `payload`, `contentType`, and `attributes` from the event. Off-chain indexers reconstruct from transaction calldata.
- **Removed `MAX_PAYLOAD_SIZE` constant**: payload is uncapped — gas is self-limiting and caller-paid. Kept `MAX_ATTRIBUTES` (32) and `MAX_STRING_ATTR_SIZE` (1KB) as application-level bounds, moved to `EntityHashing` library.
- **25 unit tests** for `_create` via harness (`test/unit/ops/Create.t.sol`): validation reverts, state mutations, key determinism, event emission, hash correctness, edge cases.