### PR TITLE
Implement _update operation with errors and unit tests

### DIFF
--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -101,6 +101,15 @@ library EntityHashing {
     error ExpiryInPast(BlockNumber expiresAt, BlockNumber currentBlock);
     error TooManyAttributes(uint256 count, uint256 maxCount);
 
+    /// @dev Reverted when an entity key does not exist in storage.
+    error EntityNotFound(bytes32 entityKey);
+
+    /// @dev Reverted when the caller is not the entity owner.
+    error NotOwner(bytes32 entityKey, address caller, address owner);
+
+    /// @dev Reverted when an operation targets an expired entity.
+    error EntityExpired(bytes32 entityKey, BlockNumber expiresAt);
+
     // -------------------------------------------------------------------------
     // Constants
     // -------------------------------------------------------------------------

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -55,6 +55,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // -------------------------------------------------------------------------
 
     event EntityCreated(bytes32 indexed entityKey, address indexed owner, BlockNumber expiresAt, bytes32 entityHash);
+    event EntityUpdated(bytes32 indexed entityKey, address indexed owner, bytes32 entityHash);
 
     // -------------------------------------------------------------------------
     // State — linked list pointers
@@ -181,17 +182,20 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // Internal functions — entity hash (requires domain separator)
     // -------------------------------------------------------------------------
 
-    /// @dev Compute the two-level EIP-712 hash for entity creation:
-    ///   coreHash: immutable content identity (survives transfers and expiry extensions)
+    /// @dev Compute the two-level EIP-712 hash:
+    ///   coreHash: immutable content identity (key, creator, createdAt, content)
     ///   entityHash: domain-wrapped hash of (coreHash, owner, updatedAt, expiresAt)
-    function _createEntityHash(bytes32 key, address creator, BlockNumber current, EntityHashing.Op calldata op)
-        internal
-        view
-        virtual
-        returns (bytes32 coreHash_, bytes32 entityHash_)
-    {
-        coreHash_ = EntityHashing.coreHash(key, creator, current, op.contentType, op.payload, op.attributes);
-        entityHash_ = _hashTypedDataV4(EntityHashing.entityStructHash(coreHash_, creator, current, op.expiresAt));
+    function _computeEntityHash(
+        bytes32 key,
+        address creator,
+        BlockNumber createdAt,
+        address owner,
+        BlockNumber updatedAt,
+        BlockNumber expiresAt,
+        EntityHashing.Op calldata op
+    ) internal view virtual returns (bytes32 coreHash_, bytes32 entityHash_) {
+        coreHash_ = EntityHashing.coreHash(key, creator, createdAt, op.contentType, op.payload, op.attributes);
+        entityHash_ = _hashTypedDataV4(EntityHashing.entityStructHash(coreHash_, owner, updatedAt, expiresAt));
     }
 
     /// @dev Mint a new entity key by post-incrementing the owner's nonce.
@@ -251,7 +255,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         key = _createEntityKey(msg.sender);
 
         bytes32 coreHash_;
-        (coreHash_, entityHash_) = _createEntityHash(key, msg.sender, current, op);
+        (coreHash_, entityHash_) = _computeEntityHash(key, msg.sender, current, msg.sender, current, op.expiresAt, op);
 
         _commitments[key] = EntityHashing.Commitment({
             creator: msg.sender,
@@ -265,10 +269,45 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         emit EntityCreated(key, msg.sender, op.expiresAt, entityHash_);
     }
 
+    /// @dev Update an existing entity's payload, contentType, and attributes.
+    /// Does not change owner or expiry. The coreHash is fully recomputed from
+    /// the new content and the entity's immutable fields (key, creator, createdAt).
+    ///
+    /// Validation:
+    ///   1. Entity must exist (creator != address(0))
+    ///   2. Entity must not be expired (expiresAt > current)
+    ///   3. Caller must be the owner
+    ///   4. Attributes validated (same rules as create)
+    ///
+    /// Storage: updates coreHash and updatedAt (2 SSTOREs on the existing Commitment).
     function _update(EntityHashing.Op calldata op, BlockNumber current) internal virtual returns (bytes32, bytes32) {
-        // Validates: entity exists + not expired + msg.sender is owner, content type, payload, attributes (same as create)
-        // Then: recompute coreHash from new content, update entity, recompute entityHash
-        revert("not implemented");
+        bytes32 key = op.entityKey;
+        EntityHashing.Commitment storage c = _commitments[key];
+
+        if (c.creator == address(0)) {
+            revert EntityHashing.EntityNotFound(key);
+        }
+
+        if (c.expiresAt <= current) {
+            revert EntityHashing.EntityExpired(key, c.expiresAt);
+        }
+
+        if (msg.sender != c.owner) {
+            revert EntityHashing.NotOwner(key, msg.sender, c.owner);
+        }
+
+        // TODO: contentType validation per RFC 6838 media type syntax.
+
+        // Recompute hashes with new content but immutable identity fields.
+        // Attribute validation (sorting, value type/length, count) runs inside coreHash.
+        (bytes32 coreHash_, bytes32 entityHash_) =
+            _computeEntityHash(key, c.creator, c.createdAt, c.owner, current, c.expiresAt, op);
+
+        c.coreHash = coreHash_;
+        c.updatedAt = current;
+
+        emit EntityUpdated(key, c.owner, entityHash_);
+        return (key, entityHash_);
     }
 
     function _extend(EntityHashing.Op calldata op, BlockNumber current) internal virtual returns (bytes32, bytes32) {

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -54,8 +54,12 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // Events
     // -------------------------------------------------------------------------
 
-    event EntityCreated(bytes32 indexed entityKey, address indexed owner, BlockNumber expiresAt, bytes32 entityHash);
-    event EntityUpdated(bytes32 indexed entityKey, address indexed owner, bytes32 entityHash);
+    event EntityCreated(
+        bytes32 indexed entityKey, address indexed owner, BlockNumber indexed expiresAt, bytes32 entityHash
+    );
+    event EntityUpdated(
+        bytes32 indexed entityKey, address indexed owner, BlockNumber indexed expiresAt, bytes32 entityHash
+    );
 
     // -------------------------------------------------------------------------
     // State — linked list pointers
@@ -306,7 +310,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         c.coreHash = coreHash_;
         c.updatedAt = current;
 
-        emit EntityUpdated(key, c.owner, entityHash_);
+        emit EntityUpdated(key, c.owner, c.expiresAt, entityHash_);
         return (key, entityHash_);
     }
 

--- a/test/unit/ComputeEntityHash.t.sol
+++ b/test/unit/ComputeEntityHash.t.sol
@@ -7,17 +7,21 @@ import {Lib} from "../utils/Lib.sol";
 import {EntityHashing} from "../../src/EntityHashing.sol";
 import {EntityRegistry} from "../../src/EntityRegistry.sol";
 
-/// @dev Tests _createEntityHash in isolation — verifies the two-level EIP-712
+/// @dev Tests _computeEntityHash in isolation — verifies the two-level EIP-712
 /// hash (coreHash + entityHash) matches manual computation.
-contract CreateEntityHashTest is Test, EntityRegistry {
+contract ComputeEntityHashTest is Test, EntityRegistry {
     address alice = makeAddr("alice");
 
-    function doCreateEntityHash(bytes32 key, address creator, BlockNumber current, EntityHashing.Op calldata op)
-        external
-        view
-        returns (bytes32, bytes32)
-    {
-        return _createEntityHash(key, creator, current, op);
+    function doComputeEntityHash(
+        bytes32 key,
+        address creator,
+        BlockNumber createdAt,
+        address owner,
+        BlockNumber updatedAt,
+        BlockNumber expiresAt,
+        EntityHashing.Op calldata op
+    ) external view returns (bytes32, bytes32) {
+        return _computeEntityHash(key, creator, createdAt, owner, updatedAt, expiresAt, op);
     }
 
     function doCoreHash(
@@ -43,7 +47,7 @@ contract CreateEntityHashTest is Test, EntityRegistry {
         attrs[0] = Lib.uintAttr("count", 42);
         EntityHashing.Op memory op = Lib.createOp("hello", "text/plain", attrs, currentBlock() + BlockNumber.wrap(1000));
 
-        (bytes32 coreHash_,) = this.doCreateEntityHash(key, alice, current, op);
+        (bytes32 coreHash_,) = this.doComputeEntityHash(key, alice, current, alice, current, op.expiresAt, op);
         bytes32 expected = this.doCoreHash(key, alice, current, "text/plain", "hello", attrs);
 
         assertEq(coreHash_, expected);
@@ -60,7 +64,8 @@ contract CreateEntityHashTest is Test, EntityRegistry {
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
         EntityHashing.Op memory op = Lib.createOp("hello", "text/plain", attrs, currentBlock() + BlockNumber.wrap(1000));
 
-        (bytes32 coreHash_, bytes32 entityHash_) = this.doCreateEntityHash(key, alice, current, op);
+        (bytes32 coreHash_, bytes32 entityHash_) =
+            this.doComputeEntityHash(key, alice, current, alice, current, op.expiresAt, op);
 
         // Manually compute: domain-wrapped entityStructHash
         bytes32 structHash = EntityHashing.entityStructHash(coreHash_, alice, current, op.expiresAt);
@@ -80,8 +85,10 @@ contract CreateEntityHashTest is Test, EntityRegistry {
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
         EntityHashing.Op memory op = Lib.createOp("hello", "text/plain", attrs, currentBlock() + BlockNumber.wrap(1000));
 
-        (bytes32 coreA, bytes32 entityA) = this.doCreateEntityHash(key, alice, current, op);
-        (bytes32 coreB, bytes32 entityB) = this.doCreateEntityHash(key, alice, current, op);
+        (bytes32 coreA, bytes32 entityA) =
+            this.doComputeEntityHash(key, alice, current, alice, current, op.expiresAt, op);
+        (bytes32 coreB, bytes32 entityB) =
+            this.doComputeEntityHash(key, alice, current, alice, current, op.expiresAt, op);
 
         assertEq(coreA, coreB);
         assertEq(entityA, entityB);
@@ -100,8 +107,8 @@ contract CreateEntityHashTest is Test, EntityRegistry {
         EntityHashing.Op memory opA = Lib.createOp("hello", "text/plain", attrs, expiry);
         EntityHashing.Op memory opB = Lib.createOp("world", "text/plain", attrs, expiry);
 
-        (bytes32 coreA,) = this.doCreateEntityHash(key, alice, current, opA);
-        (bytes32 coreB,) = this.doCreateEntityHash(key, alice, current, opB);
+        (bytes32 coreA,) = this.doComputeEntityHash(key, alice, current, alice, current, opA.expiresAt, opA);
+        (bytes32 coreB,) = this.doComputeEntityHash(key, alice, current, alice, current, opB.expiresAt, opB);
 
         assertNotEq(coreA, coreB);
     }
@@ -114,8 +121,10 @@ contract CreateEntityHashTest is Test, EntityRegistry {
         EntityHashing.Op memory opA = Lib.createOp("hello", "text/plain", attrs, BlockNumber.wrap(500));
         EntityHashing.Op memory opB = Lib.createOp("hello", "text/plain", attrs, BlockNumber.wrap(600));
 
-        (bytes32 coreA, bytes32 entityA) = this.doCreateEntityHash(key, alice, current, opA);
-        (bytes32 coreB, bytes32 entityB) = this.doCreateEntityHash(key, alice, current, opB);
+        (bytes32 coreA, bytes32 entityA) =
+            this.doComputeEntityHash(key, alice, current, alice, current, opA.expiresAt, opA);
+        (bytes32 coreB, bytes32 entityB) =
+            this.doComputeEntityHash(key, alice, current, alice, current, opB.expiresAt, opB);
 
         // Same content → same coreHash
         assertEq(coreA, coreB);
@@ -137,8 +146,8 @@ contract CreateEntityHashTest is Test, EntityRegistry {
         EntityHashing.Op memory opA = Lib.createOp("hello", "text/plain", attrsA, expiry);
         EntityHashing.Op memory opB = Lib.createOp("hello", "text/plain", attrsB, expiry);
 
-        (bytes32 coreA,) = this.doCreateEntityHash(key, alice, current, opA);
-        (bytes32 coreB,) = this.doCreateEntityHash(key, alice, current, opB);
+        (bytes32 coreA,) = this.doComputeEntityHash(key, alice, current, alice, current, opA.expiresAt, opA);
+        (bytes32 coreB,) = this.doComputeEntityHash(key, alice, current, alice, current, opB.expiresAt, opB);
 
         assertNotEq(coreA, coreB);
     }

--- a/test/unit/ops/Create.t.sol
+++ b/test/unit/ops/Create.t.sol
@@ -23,12 +23,15 @@ contract CreateTest is Test, EntityRegistry {
         return STUB_KEY;
     }
 
-    function _createEntityHash(bytes32, address, BlockNumber, EntityHashing.Op calldata)
-        internal
-        pure
-        override
-        returns (bytes32, bytes32)
-    {
+    function _computeEntityHash(
+        bytes32,
+        address,
+        BlockNumber,
+        address,
+        BlockNumber,
+        BlockNumber,
+        EntityHashing.Op calldata
+    ) internal pure override returns (bytes32, bytes32) {
         return (STUB_CORE_HASH, STUB_ENTITY_HASH);
     }
 

--- a/test/unit/ops/Update.t.sol
+++ b/test/unit/ops/Update.t.sol
@@ -190,8 +190,8 @@ contract UpdateTest is Test, EntityRegistry {
         EntityHashing.Op memory op = _simpleUpdateOp();
 
         vm.prank(alice);
-        vm.expectEmit(true, true, false, false);
-        emit EntityUpdated(testKey, alice, bytes32(0));
+        vm.expectEmit(true, true, true, false);
+        emit EntityUpdated(testKey, alice, expiresAt, bytes32(0));
         this.doUpdate(op);
     }
 

--- a/test/unit/ops/Update.t.sol
+++ b/test/unit/ops/Update.t.sol
@@ -1,0 +1,246 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {BlockNumber, currentBlock} from "../../../src/BlockNumber.sol";
+import {Test} from "forge-std/Test.sol";
+import {Lib} from "../../utils/Lib.sol";
+import {EntityHashing} from "../../../src/EntityHashing.sol";
+import {EntityRegistry} from "../../../src/EntityRegistry.sol";
+
+contract UpdateTest is Test, EntityRegistry {
+    address alice = makeAddr("alice");
+    address bob = makeAddr("bob");
+
+    BlockNumber expiresAt;
+    bytes32 testKey;
+
+    // Calldata wrappers.
+    function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
+        return _create(op, currentBlock());
+    }
+
+    function doUpdate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
+        return _update(op, currentBlock());
+    }
+
+    function hashCore(
+        bytes32 key,
+        address creator,
+        BlockNumber createdAt,
+        string calldata contentType,
+        bytes calldata payload,
+        EntityHashing.Attribute[] calldata attributes
+    ) external pure returns (bytes32) {
+        return EntityHashing.coreHash(key, creator, createdAt, contentType, payload, attributes);
+    }
+
+    function setUp() public {
+        expiresAt = currentBlock() + BlockNumber.wrap(1000);
+
+        // Create an entity owned by alice.
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory createOp = Lib.createOp("hello", "text/plain", attrs, expiresAt);
+        vm.prank(alice);
+        (testKey,) = this.doCreate(createOp);
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    function _simpleUpdateOp() internal view returns (EntityHashing.Op memory) {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        return Lib.updateOp(testKey, "world", "text/plain", attrs);
+    }
+
+    // =========================================================================
+    // Validation — entity not found
+    // =========================================================================
+
+    function test_update_nonExistentEntity_reverts() public {
+        bytes32 bogus = keccak256("bogus");
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory op = Lib.updateOp(bogus, "data", "text/plain", attrs);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, bogus));
+        this.doUpdate(op);
+    }
+
+    // =========================================================================
+    // Validation — expired entity
+    // =========================================================================
+
+    function test_update_expiredEntity_reverts() public {
+        vm.roll(BlockNumber.unwrap(expiresAt) + 1);
+
+        EntityHashing.Op memory op = _simpleUpdateOp();
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
+        this.doUpdate(op);
+    }
+
+    function test_update_atExpiryBlock_reverts() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        EntityHashing.Op memory op = _simpleUpdateOp();
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
+        this.doUpdate(op);
+    }
+
+    // =========================================================================
+    // Validation — not owner
+    // =========================================================================
+
+    function test_update_notOwner_reverts() public {
+        EntityHashing.Op memory op = _simpleUpdateOp();
+
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NotOwner.selector, testKey, bob, alice));
+        this.doUpdate(op);
+    }
+
+    // =========================================================================
+    // State — commitment updates
+    // =========================================================================
+
+    function test_update_updatesCoreHash() public {
+        EntityHashing.Commitment memory before_ = getCommitment(testKey);
+
+        EntityHashing.Op memory op = _simpleUpdateOp();
+        vm.prank(alice);
+        this.doUpdate(op);
+
+        EntityHashing.Commitment memory after_ = getCommitment(testKey);
+        assertNotEq(after_.coreHash, before_.coreHash);
+    }
+
+    function test_update_updatesUpdatedAt() public {
+        vm.roll(block.number + 10);
+
+        EntityHashing.Op memory op = _simpleUpdateOp();
+        vm.prank(alice);
+        this.doUpdate(op);
+
+        EntityHashing.Commitment memory after_ = getCommitment(testKey);
+        assertEq(BlockNumber.unwrap(after_.updatedAt), uint32(block.number));
+    }
+
+    function test_update_preservesImmutableFields() public {
+        EntityHashing.Commitment memory before_ = getCommitment(testKey);
+
+        EntityHashing.Op memory op = _simpleUpdateOp();
+        vm.prank(alice);
+        this.doUpdate(op);
+
+        EntityHashing.Commitment memory after_ = getCommitment(testKey);
+        assertEq(after_.creator, before_.creator);
+        assertEq(after_.owner, before_.owner);
+        assertEq(BlockNumber.unwrap(after_.createdAt), BlockNumber.unwrap(before_.createdAt));
+        assertEq(BlockNumber.unwrap(after_.expiresAt), BlockNumber.unwrap(before_.expiresAt));
+    }
+
+    // =========================================================================
+    // State — returns correct key
+    // =========================================================================
+
+    function test_update_returnsEntityKey() public {
+        EntityHashing.Op memory op = _simpleUpdateOp();
+        vm.prank(alice);
+        (bytes32 returnedKey,) = this.doUpdate(op);
+
+        assertEq(returnedKey, testKey);
+    }
+
+    // =========================================================================
+    // Hash correctness
+    // =========================================================================
+
+    function test_update_coreHashMatchesManualComputation() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](1);
+        attrs[0] = Lib.uintAttr("count", 99);
+        EntityHashing.Op memory op = Lib.updateOp(testKey, "new payload", "text/plain", attrs);
+
+        vm.prank(alice);
+        this.doUpdate(op);
+
+        EntityHashing.Commitment memory c = getCommitment(testKey);
+        bytes32 expected = this.hashCore(testKey, c.creator, c.createdAt, "text/plain", "new payload", attrs);
+        assertEq(c.coreHash, expected);
+    }
+
+    function test_update_entityHashMatchesManualComputation() public {
+        EntityHashing.Op memory op = _simpleUpdateOp();
+
+        vm.prank(alice);
+        (, bytes32 entityHash_) = this.doUpdate(op);
+
+        EntityHashing.Commitment memory c = getCommitment(testKey);
+        bytes32 expected =
+            _hashTypedDataV4(EntityHashing.entityStructHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt));
+        assertEq(entityHash_, expected);
+    }
+
+    // =========================================================================
+    // Event
+    // =========================================================================
+
+    function test_update_emitsEntityUpdated() public {
+        EntityHashing.Op memory op = _simpleUpdateOp();
+
+        vm.prank(alice);
+        vm.expectEmit(true, true, false, false);
+        emit EntityUpdated(testKey, alice, bytes32(0));
+        this.doUpdate(op);
+    }
+
+    // =========================================================================
+    // Edge cases
+    // =========================================================================
+
+    function test_update_sameContentProducesSameCoreHash() public {
+        EntityHashing.Commitment memory before_ = getCommitment(testKey);
+
+        // Update with the exact same content as the original create.
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory op = Lib.updateOp(testKey, "hello", "text/plain", attrs);
+
+        vm.prank(alice);
+        this.doUpdate(op);
+
+        EntityHashing.Commitment memory after_ = getCommitment(testKey);
+        assertEq(after_.coreHash, before_.coreHash);
+    }
+
+    function test_update_emptyPayloadAndAttributes() public {
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory op = Lib.updateOp(testKey, "", "text/plain", attrs);
+
+        vm.prank(alice);
+        (bytes32 key, bytes32 entityHash_) = this.doUpdate(op);
+
+        assertEq(key, testKey);
+        assertTrue(entityHash_ != bytes32(0));
+    }
+
+    function test_update_multipleUpdatesChain() public {
+        // First update.
+        EntityHashing.Attribute[] memory attrs1 = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory op1 = Lib.updateOp(testKey, "v2", "text/plain", attrs1);
+        vm.prank(alice);
+        this.doUpdate(op1);
+
+        EntityHashing.Commitment memory mid = getCommitment(testKey);
+
+        // Second update with different content.
+        EntityHashing.Attribute[] memory attrs2 = new EntityHashing.Attribute[](1);
+        attrs2[0] = Lib.uintAttr("version", 3);
+        EntityHashing.Op memory op2 = Lib.updateOp(testKey, "v3", "application/json", attrs2);
+        vm.prank(alice);
+        this.doUpdate(op2);
+
+        EntityHashing.Commitment memory final_ = getCommitment(testKey);
+        assertNotEq(final_.coreHash, mid.coreHash);
+    }
+}

--- a/test/utils/Lib.sol
+++ b/test/utils/Lib.sol
@@ -31,6 +31,23 @@ library Lib {
         });
     }
 
+    function updateOp(
+        bytes32 entityKey_,
+        bytes memory payload_,
+        string memory contentType_,
+        EntityHashing.Attribute[] memory attributes_
+    ) internal pure returns (EntityHashing.Op memory) {
+        return EntityHashing.Op({
+            opType: EntityHashing.UPDATE,
+            entityKey: entityKey_,
+            payload: payload_,
+            contentType: contentType_,
+            attributes: attributes_,
+            expiresAt: BlockNumber.wrap(0),
+            newOwner: address(0)
+        });
+    }
+
     function uintAttr(string memory name, uint256 value) internal pure returns (EntityHashing.Attribute memory) {
         return
             EntityHashing.Attribute({


### PR DESCRIPTION
- **Added entity mutation errors** to `EntityHashing`: `EntityNotFound`, `NotOwner`, `EntityExpired`. These are shared guards for all ops that mutate existing entities (update, extend, transfer, delete, expire).

- **Added `EntityUpdated` event**: slim notification (indexed entityKey + owner, entityHash). No payload/contentType/attributes — recoverable from calldata.

- **Implemented `_update`**: verifies existence (`creator != address(0)`), expiry (`expiresAt > current`), and ownership (`msg.sender == owner`). Recomputes `coreHash` from new content + immutable identity fields (key, creator, createdAt). Updates only `coreHash` and `updatedAt` (2 SSTOREs). Does not change owner or expiry.

- **14 unit tests** (`test/unit/ops/Update.t.sol`): follows the self-contained pattern (`is Test, EntityRegistry` with `_validateAttributes` stubbed out). Tests entity not found, expired, at expiry block, not owner, coreHash/updatedAt mutation, immutable field preservation, key return, hash correctness against manual EIP-712 computation, event emission, same-content idempotency, empty payload, sequential update chaining.

- **Added `Lib.updateOp`** helper for constructing UPDATE ops in tests.