### PR TITLE
Implement _extend operation with unit tests

### DIFF
--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -110,6 +110,9 @@ library EntityHashing {
     /// @dev Reverted when an operation targets an expired entity.
     error EntityExpired(bytes32 entityKey, BlockNumber expiresAt);
 
+    /// @dev Reverted when new expiresAt is not strictly greater than current.
+    error ExpiryNotExtended(bytes32 entityKey, BlockNumber newExpiresAt, BlockNumber currentExpiresAt);
+
     // -------------------------------------------------------------------------
     // Constants
     // -------------------------------------------------------------------------

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -60,6 +60,9 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     event EntityUpdated(
         bytes32 indexed entityKey, address indexed owner, BlockNumber indexed expiresAt, bytes32 entityHash
     );
+    event EntityExtended(
+        bytes32 indexed entityKey, address indexed owner, bytes32 entityHash, BlockNumber newExpiresAt
+    );
 
     // -------------------------------------------------------------------------
     // State — linked list pointers
@@ -314,10 +317,43 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         return (key, entityHash_);
     }
 
+    /// @dev Extend an entity's expiry. Does not change payload, attributes, or owner.
+    /// The entityHash is recomputed from the stored coreHash with the new expiresAt.
+    ///
+    /// Validation:
+    ///   1. Entity must exist (creator != address(0))
+    ///   2. Entity must not be expired (expiresAt > current)
+    ///   3. Caller must be the owner
+    ///   4. New expiresAt must be strictly greater than current expiresAt
+    ///
+    /// Storage: updates expiresAt and updatedAt (1 SSTORE — both pack into slot 0).
     function _extend(EntityHashing.Op calldata op, BlockNumber current) internal virtual returns (bytes32, bytes32) {
-        // Validates: entity exists + not expired + msg.sender is owner, new expiresAt > current expiresAt
-        // Then: update expiresAt + updatedAt, recompute entityHash from stored coreHash
-        revert("not implemented");
+        bytes32 key = op.entityKey;
+        EntityHashing.Commitment storage c = _commitments[key];
+
+        if (c.creator == address(0)) {
+            revert EntityHashing.EntityNotFound(key);
+        }
+
+        if (c.expiresAt <= current) {
+            revert EntityHashing.EntityExpired(key, c.expiresAt);
+        }
+
+        if (msg.sender != c.owner) {
+            revert EntityHashing.NotOwner(key, msg.sender, c.owner);
+        }
+
+        if (op.expiresAt <= c.expiresAt) {
+            revert EntityHashing.ExpiryNotExtended(key, op.expiresAt, c.expiresAt);
+        }
+
+        c.expiresAt = op.expiresAt;
+        c.updatedAt = current;
+
+        bytes32 entityHash_ = _entityHash(c.coreHash, c.owner, current, op.expiresAt);
+
+        emit EntityExtended(key, c.owner, entityHash_, op.expiresAt);
+        return (key, entityHash_);
     }
 
     function _transfer(EntityHashing.Op calldata op, BlockNumber current) internal virtual returns (bytes32, bytes32) {

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -189,6 +189,17 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // Internal functions — entity hash (requires domain separator)
     // -------------------------------------------------------------------------
 
+    /// @dev Domain-wrap an entity struct hash. Used by both _computeEntityHash
+    /// and operations that recompute entityHash without changing coreHash (extend, transfer).
+    function _wrapEntityHash(bytes32 coreHash_, address owner, BlockNumber updatedAt, BlockNumber expiresAt)
+        internal
+        view
+        virtual
+        returns (bytes32)
+    {
+        return _hashTypedDataV4(EntityHashing.entityStructHash(coreHash_, owner, updatedAt, expiresAt));
+    }
+
     /// @dev Compute the two-level EIP-712 hash:
     ///   coreHash: immutable content identity (key, creator, createdAt, content)
     ///   entityHash: domain-wrapped hash of (coreHash, owner, updatedAt, expiresAt)
@@ -202,7 +213,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         EntityHashing.Op calldata op
     ) internal view virtual returns (bytes32 coreHash_, bytes32 entityHash_) {
         coreHash_ = EntityHashing.coreHash(key, creator, createdAt, op.contentType, op.payload, op.attributes);
-        entityHash_ = _hashTypedDataV4(EntityHashing.entityStructHash(coreHash_, owner, updatedAt, expiresAt));
+        entityHash_ = _wrapEntityHash(coreHash_, owner, updatedAt, expiresAt);
     }
 
     /// @dev Mint a new entity key by post-incrementing the owner's nonce.
@@ -350,7 +361,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         c.expiresAt = op.expiresAt;
         c.updatedAt = current;
 
-        bytes32 entityHash_ = _entityHash(c.coreHash, c.owner, current, op.expiresAt);
+        bytes32 entityHash_ = _wrapEntityHash(c.coreHash, c.owner, current, op.expiresAt);
 
         emit EntityExtended(key, c.owner, entityHash_, op.expiresAt);
         return (key, entityHash_);

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -61,7 +61,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         bytes32 indexed entityKey, address indexed owner, BlockNumber indexed expiresAt, bytes32 entityHash
     );
     event EntityExtended(
-        bytes32 indexed entityKey, address indexed owner, bytes32 entityHash, BlockNumber newExpiresAt
+        bytes32 indexed entityKey, address indexed owner, BlockNumber indexed newExpiresAt, bytes32 entityHash
     );
 
     // -------------------------------------------------------------------------
@@ -363,7 +363,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
 
         bytes32 entityHash_ = _wrapEntityHash(c.coreHash, c.owner, current, op.expiresAt);
 
-        emit EntityExtended(key, c.owner, entityHash_, op.expiresAt);
+        emit EntityExtended(key, c.owner, op.expiresAt, entityHash_);
         return (key, entityHash_);
     }
 

--- a/test/unit/ComputeEntityHash.t.sol
+++ b/test/unit/ComputeEntityHash.t.sol
@@ -67,9 +67,8 @@ contract ComputeEntityHashTest is Test, EntityRegistry {
         (bytes32 coreHash_, bytes32 entityHash_) =
             this.doComputeEntityHash(key, alice, current, alice, current, op.expiresAt, op);
 
-        // Manually compute: domain-wrapped entityStructHash
-        bytes32 structHash = EntityHashing.entityStructHash(coreHash_, alice, current, op.expiresAt);
-        bytes32 expected = _hashTypedDataV4(structHash);
+        // Verify entityHash matches _wrapEntityHash for the same inputs
+        bytes32 expected = _wrapEntityHash(coreHash_, alice, current, op.expiresAt);
 
         assertEq(entityHash_, expected);
     }

--- a/test/unit/WrapEntityHash.t.sol
+++ b/test/unit/WrapEntityHash.t.sol
@@ -1,0 +1,107 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {BlockNumber} from "../../src/BlockNumber.sol";
+import {Test} from "forge-std/Test.sol";
+import {EntityHashing} from "../../src/EntityHashing.sol";
+import {EntityRegistry} from "../../src/EntityRegistry.sol";
+
+/// @dev Tests _wrapEntityHash in isolation — verifies domain-wrapped
+/// EIP-712 entity struct hash matches manual computation.
+contract WrapEntityHashTest is Test, EntityRegistry {
+    address alice = makeAddr("alice");
+
+    function doWrap(bytes32 coreHash_, address owner, BlockNumber updatedAt, BlockNumber expiresAt)
+        external
+        view
+        returns (bytes32)
+    {
+        return _wrapEntityHash(coreHash_, owner, updatedAt, expiresAt);
+    }
+
+    // =========================================================================
+    // Correctness — matches manual domain wrapping
+    // =========================================================================
+
+    function test_matchesManualDomainWrapping() public {
+        bytes32 coreHash_ = keccak256("core");
+        BlockNumber updatedAt = BlockNumber.wrap(100);
+        BlockNumber expiresAt = BlockNumber.wrap(500);
+
+        bytes32 structHash = EntityHashing.entityStructHash(coreHash_, alice, updatedAt, expiresAt);
+        bytes32 expected = _hashTypedDataV4(structHash);
+
+        assertEq(this.doWrap(coreHash_, alice, updatedAt, expiresAt), expected);
+    }
+
+    // =========================================================================
+    // Determinism
+    // =========================================================================
+
+    function test_deterministic() public {
+        bytes32 coreHash_ = keccak256("core");
+        BlockNumber updatedAt = BlockNumber.wrap(100);
+        BlockNumber expiresAt = BlockNumber.wrap(500);
+
+        assertEq(
+            this.doWrap(coreHash_, alice, updatedAt, expiresAt), this.doWrap(coreHash_, alice, updatedAt, expiresAt)
+        );
+    }
+
+    // =========================================================================
+    // Different inputs produce different hashes
+    // =========================================================================
+
+    function test_differentCoreHash_differs() public {
+        BlockNumber updatedAt = BlockNumber.wrap(100);
+        BlockNumber expiresAt = BlockNumber.wrap(500);
+
+        assertNotEq(
+            this.doWrap(keccak256("a"), alice, updatedAt, expiresAt),
+            this.doWrap(keccak256("b"), alice, updatedAt, expiresAt)
+        );
+    }
+
+    function test_differentOwner_differs() public {
+        bytes32 coreHash_ = keccak256("core");
+        BlockNumber updatedAt = BlockNumber.wrap(100);
+        BlockNumber expiresAt = BlockNumber.wrap(500);
+        address bob = makeAddr("bob");
+
+        assertNotEq(
+            this.doWrap(coreHash_, alice, updatedAt, expiresAt), this.doWrap(coreHash_, bob, updatedAt, expiresAt)
+        );
+    }
+
+    function test_differentUpdatedAt_differs() public {
+        bytes32 coreHash_ = keccak256("core");
+        BlockNumber expiresAt = BlockNumber.wrap(500);
+
+        assertNotEq(
+            this.doWrap(coreHash_, alice, BlockNumber.wrap(100), expiresAt),
+            this.doWrap(coreHash_, alice, BlockNumber.wrap(200), expiresAt)
+        );
+    }
+
+    function test_differentExpiresAt_differs() public {
+        bytes32 coreHash_ = keccak256("core");
+        BlockNumber updatedAt = BlockNumber.wrap(100);
+
+        assertNotEq(
+            this.doWrap(coreHash_, alice, updatedAt, BlockNumber.wrap(500)),
+            this.doWrap(coreHash_, alice, updatedAt, BlockNumber.wrap(600))
+        );
+    }
+
+    // =========================================================================
+    // Fuzz
+    // =========================================================================
+
+    function test_fuzz(bytes32 coreHash_, address owner, uint32 rawUpdatedAt, uint32 rawExpiresAt) public {
+        BlockNumber updatedAt = BlockNumber.wrap(rawUpdatedAt);
+        BlockNumber expiresAt = BlockNumber.wrap(rawExpiresAt);
+
+        bytes32 expected = _hashTypedDataV4(EntityHashing.entityStructHash(coreHash_, owner, updatedAt, expiresAt));
+        assertEq(this.doWrap(coreHash_, owner, updatedAt, expiresAt), expected);
+    }
+}

--- a/test/unit/ops/Extend.t.sol
+++ b/test/unit/ops/Extend.t.sol
@@ -1,0 +1,212 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {BlockNumber, currentBlock} from "../../../src/BlockNumber.sol";
+import {Test} from "forge-std/Test.sol";
+import {Lib} from "../../utils/Lib.sol";
+import {EntityHashing} from "../../../src/EntityHashing.sol";
+import {EntityRegistry} from "../../../src/EntityRegistry.sol";
+
+contract ExtendTest is Test, EntityRegistry {
+    address alice = makeAddr("alice");
+    address bob = makeAddr("bob");
+
+    BlockNumber expiresAt;
+    bytes32 testKey;
+
+    function _validateAttributes(EntityHashing.Attribute[] calldata) internal pure override {}
+
+    function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
+        return _create(op, currentBlock());
+    }
+
+    function doExtend(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
+        return _extend(op, currentBlock());
+    }
+
+    function setUp() public {
+        expiresAt = currentBlock() + BlockNumber.wrap(1000);
+
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory createOp = Lib.createOp("hello", "text/plain", attrs, expiresAt);
+        vm.prank(alice);
+        (testKey,) = this.doCreate(createOp);
+    }
+
+    // =========================================================================
+    // Validation — entity not found
+    // =========================================================================
+
+    function test_extend_nonExistentEntity_reverts() public {
+        bytes32 bogus = keccak256("bogus");
+        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
+        EntityHashing.Op memory op = Lib.extendOp(bogus, newExpiry);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, bogus));
+        this.doExtend(op);
+    }
+
+    // =========================================================================
+    // Validation — expired entity
+    // =========================================================================
+
+    function test_extend_expiredEntity_reverts() public {
+        vm.roll(BlockNumber.unwrap(expiresAt) + 1);
+
+        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
+        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
+        this.doExtend(op);
+    }
+
+    function test_extend_atExpiryBlock_reverts() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
+        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
+        this.doExtend(op);
+    }
+
+    // =========================================================================
+    // Validation — not owner
+    // =========================================================================
+
+    function test_extend_notOwner_reverts() public {
+        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
+        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
+
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NotOwner.selector, testKey, bob, alice));
+        this.doExtend(op);
+    }
+
+    // =========================================================================
+    // Validation — expiry not extended
+    // =========================================================================
+
+    function test_extend_sameExpiry_reverts() public {
+        EntityHashing.Op memory op = Lib.extendOp(testKey, expiresAt);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.ExpiryNotExtended.selector, testKey, expiresAt, expiresAt));
+        this.doExtend(op);
+    }
+
+    function test_extend_lowerExpiry_reverts() public {
+        BlockNumber lower = expiresAt - BlockNumber.wrap(100);
+        EntityHashing.Op memory op = Lib.extendOp(testKey, lower);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.ExpiryNotExtended.selector, testKey, lower, expiresAt));
+        this.doExtend(op);
+    }
+
+    // =========================================================================
+    // State — commitment updates
+    // =========================================================================
+
+    function test_extend_updatesExpiresAt() public {
+        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
+        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
+
+        vm.prank(alice);
+        this.doExtend(op);
+
+        EntityHashing.Commitment memory c = getCommitment(testKey);
+        assertEq(BlockNumber.unwrap(c.expiresAt), BlockNumber.unwrap(newExpiry));
+    }
+
+    function test_extend_updatesUpdatedAt() public {
+        vm.roll(block.number + 10);
+
+        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
+        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
+
+        vm.prank(alice);
+        this.doExtend(op);
+
+        EntityHashing.Commitment memory c = getCommitment(testKey);
+        assertEq(BlockNumber.unwrap(c.updatedAt), uint32(block.number));
+    }
+
+    function test_extend_preservesCoreHashAndOwner() public {
+        EntityHashing.Commitment memory before_ = getCommitment(testKey);
+
+        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
+        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
+
+        vm.prank(alice);
+        this.doExtend(op);
+
+        EntityHashing.Commitment memory after_ = getCommitment(testKey);
+        assertEq(after_.coreHash, before_.coreHash);
+        assertEq(after_.creator, before_.creator);
+        assertEq(after_.owner, before_.owner);
+        assertEq(BlockNumber.unwrap(after_.createdAt), BlockNumber.unwrap(before_.createdAt));
+    }
+
+    // =========================================================================
+    // State — returns correct key
+    // =========================================================================
+
+    function test_extend_returnsEntityKey() public {
+        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
+        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
+
+        vm.prank(alice);
+        (bytes32 returnedKey,) = this.doExtend(op);
+
+        assertEq(returnedKey, testKey);
+    }
+
+    // =========================================================================
+    // Hash correctness
+    // =========================================================================
+
+    function test_extend_entityHashUsesNewExpiry() public {
+        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
+        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
+
+        vm.prank(alice);
+        (, bytes32 entityHash_) = this.doExtend(op);
+
+        EntityHashing.Commitment memory c = getCommitment(testKey);
+        bytes32 expected = _entityHash(c.coreHash, c.owner, c.updatedAt, newExpiry);
+        assertEq(entityHash_, expected);
+    }
+
+    function test_extend_differentExpiry_differentEntityHash() public {
+        BlockNumber expiry1 = expiresAt + BlockNumber.wrap(100);
+        BlockNumber expiry2 = expiresAt + BlockNumber.wrap(200);
+
+        EntityHashing.Op memory op1 = Lib.extendOp(testKey, expiry1);
+        vm.prank(alice);
+        (, bytes32 hash1) = this.doExtend(op1);
+
+        EntityHashing.Op memory op2 = Lib.extendOp(testKey, expiry2);
+        vm.prank(alice);
+        (, bytes32 hash2) = this.doExtend(op2);
+
+        assertNotEq(hash1, hash2);
+    }
+
+    // =========================================================================
+    // Event
+    // =========================================================================
+
+    function test_extend_emitsEntityExtended() public {
+        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
+        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
+
+        vm.prank(alice);
+        vm.expectEmit(true, true, false, false);
+        emit EntityExtended(testKey, alice, bytes32(0), newExpiry);
+        this.doExtend(op);
+    }
+}

--- a/test/unit/ops/Extend.t.sol
+++ b/test/unit/ops/Extend.t.sol
@@ -14,8 +14,6 @@ contract ExtendTest is Test, EntityRegistry {
     BlockNumber expiresAt;
     bytes32 testKey;
 
-    function _validateAttributes(EntityHashing.Attribute[] calldata) internal pure override {}
-
     function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
         return _create(op, currentBlock());
     }
@@ -177,7 +175,7 @@ contract ExtendTest is Test, EntityRegistry {
         (, bytes32 entityHash_) = this.doExtend(op);
 
         EntityHashing.Commitment memory c = getCommitment(testKey);
-        bytes32 expected = _entityHash(c.coreHash, c.owner, c.updatedAt, newExpiry);
+        bytes32 expected = _wrapEntityHash(c.coreHash, c.owner, c.updatedAt, newExpiry);
         assertEq(entityHash_, expected);
     }
 

--- a/test/unit/ops/Extend.t.sol
+++ b/test/unit/ops/Extend.t.sol
@@ -203,8 +203,8 @@ contract ExtendTest is Test, EntityRegistry {
         EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
 
         vm.prank(alice);
-        vm.expectEmit(true, true, false, false);
-        emit EntityExtended(testKey, alice, bytes32(0), newExpiry);
+        vm.expectEmit(true, true, true, false);
+        emit EntityExtended(testKey, alice, newExpiry, bytes32(0));
         this.doExtend(op);
     }
 }

--- a/test/unit/ops/Update.t.sol
+++ b/test/unit/ops/Update.t.sol
@@ -177,8 +177,7 @@ contract UpdateTest is Test, EntityRegistry {
         (, bytes32 entityHash_) = this.doUpdate(op);
 
         EntityHashing.Commitment memory c = getCommitment(testKey);
-        bytes32 expected =
-            _hashTypedDataV4(EntityHashing.entityStructHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt));
+        bytes32 expected = _wrapEntityHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt);
         assertEq(entityHash_, expected);
     }
 

--- a/test/utils/Lib.sol
+++ b/test/utils/Lib.sol
@@ -48,6 +48,19 @@ library Lib {
         });
     }
 
+    function extendOp(bytes32 entityKey_, BlockNumber expiresAt_) internal pure returns (EntityHashing.Op memory) {
+        EntityHashing.Attribute[] memory empty = new EntityHashing.Attribute[](0);
+        return EntityHashing.Op({
+            opType: EntityHashing.EXTEND,
+            entityKey: entityKey_,
+            payload: "",
+            contentType: "",
+            attributes: empty,
+            expiresAt: expiresAt_,
+            newOwner: address(0)
+        });
+    }
+
     function uintAttr(string memory name, uint256 value) internal pure returns (EntityHashing.Attribute memory) {
         return
             EntityHashing.Attribute({


### PR DESCRIPTION
- **Added `ExpiryNotExtended` error** to `EntityHashing`: reverts when new `expiresAt` is not strictly greater than current. Includes both values for debuggability.

- **Added `EntityExtended` event**: indexed entityKey + owner, entityHash, newExpiresAt.

- **Implemented `_extend`**: same existence/expiry/ownership guards as `_update`. New `expiresAt` must strictly exceed current (rejects equal or lower). Updates `expiresAt` and `updatedAt` — both pack into slot 0 with `creator`, so this is a single SSTORE. Recomputes `entityHash` from stored `coreHash` with the new expiry. No content change, no `_validateAttributes` call. `coreHash` is preserved.

- **13 unit tests** (`test/unit/ops/Extend.t.sol`): entity not found, expired, at expiry block, not owner, same expiry reverts, lower expiry reverts, expiresAt updates, updatedAt advances, coreHash/owner/creator preserved, returns correct key, entityHash uses new expiry, different expiry produces different hash, event emission.

- **Added `Lib.extendOp`** helper for constructing EXTEND ops in tests.