### PR TITLE
Implement _transfer operation with unit tests

### DIFF
--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -113,6 +113,9 @@ library EntityHashing {
     /// @dev Reverted when new expiresAt is not strictly greater than current.
     error ExpiryNotExtended(bytes32 entityKey, BlockNumber newExpiresAt, BlockNumber currentExpiresAt);
 
+    /// @dev Reverted when transfer target is the zero address.
+    error TransferToZeroAddress(bytes32 entityKey);
+
     // -------------------------------------------------------------------------
     // Constants
     // -------------------------------------------------------------------------

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -404,7 +404,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         c.owner = op.newOwner;
         c.updatedAt = current;
 
-        bytes32 entityHash_ = _entityHash(c.coreHash, op.newOwner, current, c.expiresAt);
+        bytes32 entityHash_ = _wrapEntityHash(c.coreHash, op.newOwner, current, c.expiresAt);
 
         emit EntityTransferred(key, previousOwner, op.newOwner, entityHash_);
         return (key, entityHash_);

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -219,6 +219,24 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         entityHash_ = _wrapEntityHash(coreHash_, owner, updatedAt, expiresAt);
     }
 
+    /// @dev Require that the entity exists, is not expired, and the caller is the owner.
+    /// Shared guard for update, extend, transfer, and delete.
+    function _guardEntityMutation(bytes32 key, EntityHashing.Commitment storage c, BlockNumber current)
+        internal
+        view
+        virtual
+    {
+        if (c.creator == address(0)) {
+            revert EntityHashing.EntityNotFound(key);
+        }
+        if (c.expiresAt <= current) {
+            revert EntityHashing.EntityExpired(key, c.expiresAt);
+        }
+        if (msg.sender != c.owner) {
+            revert EntityHashing.NotOwner(key, msg.sender, c.owner);
+        }
+    }
+
     /// @dev Mint a new entity key by post-incrementing the owner's nonce.
     /// Uniqueness is guaranteed by the monotonic nonce — no existence check needed.
     function _createEntityKey(address owner) internal virtual returns (bytes32) {
@@ -304,18 +322,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     function _update(EntityHashing.Op calldata op, BlockNumber current) internal virtual returns (bytes32, bytes32) {
         bytes32 key = op.entityKey;
         EntityHashing.Commitment storage c = _commitments[key];
-
-        if (c.creator == address(0)) {
-            revert EntityHashing.EntityNotFound(key);
-        }
-
-        if (c.expiresAt <= current) {
-            revert EntityHashing.EntityExpired(key, c.expiresAt);
-        }
-
-        if (msg.sender != c.owner) {
-            revert EntityHashing.NotOwner(key, msg.sender, c.owner);
-        }
+        _guardEntityMutation(key, c, current);
 
         // TODO: contentType validation per RFC 6838 media type syntax.
 
@@ -344,18 +351,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     function _extend(EntityHashing.Op calldata op, BlockNumber current) internal virtual returns (bytes32, bytes32) {
         bytes32 key = op.entityKey;
         EntityHashing.Commitment storage c = _commitments[key];
-
-        if (c.creator == address(0)) {
-            revert EntityHashing.EntityNotFound(key);
-        }
-
-        if (c.expiresAt <= current) {
-            revert EntityHashing.EntityExpired(key, c.expiresAt);
-        }
-
-        if (msg.sender != c.owner) {
-            revert EntityHashing.NotOwner(key, msg.sender, c.owner);
-        }
+        _guardEntityMutation(key, c, current);
 
         if (op.expiresAt <= c.expiresAt) {
             revert EntityHashing.ExpiryNotExtended(key, op.expiresAt, c.expiresAt);
@@ -383,18 +379,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     function _transfer(EntityHashing.Op calldata op, BlockNumber current) internal virtual returns (bytes32, bytes32) {
         bytes32 key = op.entityKey;
         EntityHashing.Commitment storage c = _commitments[key];
-
-        if (c.creator == address(0)) {
-            revert EntityHashing.EntityNotFound(key);
-        }
-
-        if (c.expiresAt <= current) {
-            revert EntityHashing.EntityExpired(key, c.expiresAt);
-        }
-
-        if (msg.sender != c.owner) {
-            revert EntityHashing.NotOwner(key, msg.sender, c.owner);
-        }
+        _guardEntityMutation(key, c, current);
 
         if (op.newOwner == address(0)) {
             revert EntityHashing.TransferToZeroAddress(key);

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -220,7 +220,9 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     }
 
     /// @dev Require that the entity exists, is not expired, and the caller is the owner.
-    /// Shared guard for update, extend, transfer, and delete.
+    /// Shared guard for update, extend, transfer, and delete. Implemented as a
+    /// function rather than a modifier so callers can load the Commitment storage
+    /// pointer once and reuse it for both validation and state updates.
     function _guardEntityMutation(bytes32 key, EntityHashing.Commitment storage c, BlockNumber current)
         internal
         view

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -63,6 +63,9 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     event EntityExtended(
         bytes32 indexed entityKey, address indexed owner, BlockNumber indexed newExpiresAt, bytes32 entityHash
     );
+    event EntityTransferred(
+        bytes32 indexed entityKey, address indexed previousOwner, address indexed newOwner, bytes32 entityHash
+    );
 
     // -------------------------------------------------------------------------
     // State — linked list pointers
@@ -367,10 +370,44 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         return (key, entityHash_);
     }
 
+    /// @dev Transfer entity ownership. Does not change payload, attributes, or expiry.
+    /// The entityHash is recomputed from the stored coreHash with the new owner.
+    ///
+    /// Validation:
+    ///   1. Entity must exist (creator != address(0))
+    ///   2. Entity must not be expired (expiresAt > current)
+    ///   3. Caller must be the current owner
+    ///   4. New owner must not be the zero address
+    ///
+    /// Storage: updates owner and updatedAt (2 SSTOREs — owner in slot 1, updatedAt in slot 0).
     function _transfer(EntityHashing.Op calldata op, BlockNumber current) internal virtual returns (bytes32, bytes32) {
-        // Validates: entity exists + not expired + msg.sender is owner, newOwner != address(0)
-        // Then: set owner to newOwner + updatedAt, recompute entityHash from stored coreHash
-        revert("not implemented");
+        bytes32 key = op.entityKey;
+        EntityHashing.Commitment storage c = _commitments[key];
+
+        if (c.creator == address(0)) {
+            revert EntityHashing.EntityNotFound(key);
+        }
+
+        if (c.expiresAt <= current) {
+            revert EntityHashing.EntityExpired(key, c.expiresAt);
+        }
+
+        if (msg.sender != c.owner) {
+            revert EntityHashing.NotOwner(key, msg.sender, c.owner);
+        }
+
+        if (op.newOwner == address(0)) {
+            revert EntityHashing.TransferToZeroAddress(key);
+        }
+
+        address previousOwner = c.owner;
+        c.owner = op.newOwner;
+        c.updatedAt = current;
+
+        bytes32 entityHash_ = _entityHash(c.coreHash, op.newOwner, current, c.expiresAt);
+
+        emit EntityTransferred(key, previousOwner, op.newOwner, entityHash_);
+        return (key, entityHash_);
     }
 
     function _delete(EntityHashing.Op calldata op, BlockNumber current) internal virtual returns (bytes32, bytes32) {

--- a/test/unit/GuardEntityMutation.t.sol
+++ b/test/unit/GuardEntityMutation.t.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {BlockNumber, currentBlock} from "../../src/BlockNumber.sol";
+import {Test} from "forge-std/Test.sol";
+import {Lib} from "../utils/Lib.sol";
+import {EntityHashing} from "../../src/EntityHashing.sol";
+import {EntityRegistry} from "../../src/EntityRegistry.sol";
+
+/// @dev Tests _guardEntityMutation in isolation.
+contract GuardEntityMutationTest is Test, EntityRegistry {
+    address alice = makeAddr("alice");
+    address bob = makeAddr("bob");
+
+    BlockNumber expiresAt;
+    bytes32 testKey;
+
+    function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
+        return _create(op, currentBlock());
+    }
+
+    function doGuard(bytes32 key, BlockNumber current) external view {
+        EntityHashing.Commitment storage c = _commitments[key];
+        _guardEntityMutation(key, c, current);
+    }
+
+    function setUp() public {
+        expiresAt = currentBlock() + BlockNumber.wrap(1000);
+
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory op = Lib.createOp("hello", "text/plain", attrs, expiresAt);
+        vm.prank(alice);
+        (testKey,) = this.doCreate(op);
+    }
+
+    // =========================================================================
+    // Entity not found
+    // =========================================================================
+
+    function test_nonExistentEntity_reverts() public {
+        bytes32 bogus = keccak256("bogus");
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, bogus));
+        this.doGuard(bogus, currentBlock());
+    }
+
+    // =========================================================================
+    // Expired entity
+    // =========================================================================
+
+    function test_expiredEntity_reverts() public {
+        vm.roll(BlockNumber.unwrap(expiresAt) + 1);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
+        this.doGuard(testKey, currentBlock());
+    }
+
+    function test_atExpiryBlock_reverts() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
+        this.doGuard(testKey, currentBlock());
+    }
+
+    // =========================================================================
+    // Not owner
+    // =========================================================================
+
+    function test_notOwner_reverts() public {
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NotOwner.selector, testKey, bob, alice));
+        this.doGuard(testKey, currentBlock());
+    }
+
+    // =========================================================================
+    // Happy path
+    // =========================================================================
+
+    function test_validOwner_succeeds() public {
+        vm.prank(alice);
+        this.doGuard(testKey, currentBlock());
+    }
+}

--- a/test/unit/ops/Extend.t.sol
+++ b/test/unit/ops/Extend.t.sol
@@ -14,6 +14,9 @@ contract ExtendTest is Test, EntityRegistry {
     BlockNumber expiresAt;
     bytes32 testKey;
 
+    // Stub guard — tested separately in GuardEntityMutation.t.sol.
+    function _guardEntityMutation(bytes32, EntityHashing.Commitment storage, BlockNumber) internal view override {}
+
     function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
         return _create(op, currentBlock());
     }
@@ -29,59 +32,6 @@ contract ExtendTest is Test, EntityRegistry {
         EntityHashing.Op memory createOp = Lib.createOp("hello", "text/plain", attrs, expiresAt);
         vm.prank(alice);
         (testKey,) = this.doCreate(createOp);
-    }
-
-    // =========================================================================
-    // Validation — entity not found
-    // =========================================================================
-
-    function test_extend_nonExistentEntity_reverts() public {
-        bytes32 bogus = keccak256("bogus");
-        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
-        EntityHashing.Op memory op = Lib.extendOp(bogus, newExpiry);
-
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, bogus));
-        this.doExtend(op);
-    }
-
-    // =========================================================================
-    // Validation — expired entity
-    // =========================================================================
-
-    function test_extend_expiredEntity_reverts() public {
-        vm.roll(BlockNumber.unwrap(expiresAt) + 1);
-
-        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
-        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
-
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
-        this.doExtend(op);
-    }
-
-    function test_extend_atExpiryBlock_reverts() public {
-        vm.roll(BlockNumber.unwrap(expiresAt));
-
-        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
-        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
-
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
-        this.doExtend(op);
-    }
-
-    // =========================================================================
-    // Validation — not owner
-    // =========================================================================
-
-    function test_extend_notOwner_reverts() public {
-        BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
-        EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
-
-        vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NotOwner.selector, testKey, bob, alice));
-        this.doExtend(op);
     }
 
     // =========================================================================

--- a/test/unit/ops/Transfer.t.sol
+++ b/test/unit/ops/Transfer.t.sol
@@ -15,7 +15,7 @@ contract TransferTest is Test, EntityRegistry {
     BlockNumber expiresAt;
     bytes32 testKey;
 
-    function _validateAttributes(EntityHashing.Attribute[] calldata) internal pure override {}
+
 
     function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
         return _create(op, currentBlock());
@@ -188,7 +188,7 @@ contract TransferTest is Test, EntityRegistry {
         (, bytes32 entityHash_) = this.doTransfer(op);
 
         EntityHashing.Commitment memory c = getCommitment(testKey);
-        bytes32 expected = _entityHash(c.coreHash, bob, c.updatedAt, c.expiresAt);
+        bytes32 expected = _wrapEntityHash(c.coreHash, bob, c.updatedAt, c.expiresAt);
         assertEq(entityHash_, expected);
     }
 
@@ -196,7 +196,7 @@ contract TransferTest is Test, EntityRegistry {
         // Get hash with alice as owner.
         EntityHashing.Commitment memory beforeTransfer = getCommitment(testKey);
         bytes32 hashAlice =
-            _entityHash(beforeTransfer.coreHash, alice, beforeTransfer.updatedAt, beforeTransfer.expiresAt);
+            _wrapEntityHash(beforeTransfer.coreHash, alice, beforeTransfer.updatedAt, beforeTransfer.expiresAt);
 
         // Transfer to bob.
         EntityHashing.Op memory op = Lib.transferOp(testKey, bob);

--- a/test/unit/ops/Transfer.t.sol
+++ b/test/unit/ops/Transfer.t.sol
@@ -15,7 +15,8 @@ contract TransferTest is Test, EntityRegistry {
     BlockNumber expiresAt;
     bytes32 testKey;
 
-
+    // Stub guard — tested separately in GuardEntityMutation.t.sol.
+    function _guardEntityMutation(bytes32, EntityHashing.Commitment storage, BlockNumber) internal view override {}
 
     function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
         return _create(op, currentBlock());
@@ -32,53 +33,6 @@ contract TransferTest is Test, EntityRegistry {
         EntityHashing.Op memory createOp = Lib.createOp("hello", "text/plain", attrs, expiresAt);
         vm.prank(alice);
         (testKey,) = this.doCreate(createOp);
-    }
-
-    // =========================================================================
-    // Validation — entity not found
-    // =========================================================================
-
-    function test_transfer_nonExistentEntity_reverts() public {
-        bytes32 bogus = keccak256("bogus");
-        EntityHashing.Op memory op = Lib.transferOp(bogus, bob);
-
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, bogus));
-        this.doTransfer(op);
-    }
-
-    // =========================================================================
-    // Validation — expired entity
-    // =========================================================================
-
-    function test_transfer_expiredEntity_reverts() public {
-        vm.roll(BlockNumber.unwrap(expiresAt) + 1);
-
-        EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
-        this.doTransfer(op);
-    }
-
-    function test_transfer_atExpiryBlock_reverts() public {
-        vm.roll(BlockNumber.unwrap(expiresAt));
-
-        EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
-        this.doTransfer(op);
-    }
-
-    // =========================================================================
-    // Validation — not owner
-    // =========================================================================
-
-    function test_transfer_notOwner_reverts() public {
-        EntityHashing.Op memory op = Lib.transferOp(testKey, charlie);
-
-        vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NotOwner.selector, testKey, bob, alice));
-        this.doTransfer(op);
     }
 
     // =========================================================================
@@ -149,19 +103,6 @@ contract TransferTest is Test, EntityRegistry {
 
         EntityHashing.Commitment memory c = getCommitment(testKey);
         assertEq(c.owner, charlie);
-    }
-
-    function test_transfer_previousOwnerCannotOperate() public {
-        // alice → bob
-        EntityHashing.Op memory op1 = Lib.transferOp(testKey, bob);
-        vm.prank(alice);
-        this.doTransfer(op1);
-
-        // alice tries again
-        EntityHashing.Op memory op2 = Lib.transferOp(testKey, charlie);
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NotOwner.selector, testKey, alice, bob));
-        this.doTransfer(op2);
     }
 
     // =========================================================================

--- a/test/unit/ops/Transfer.t.sol
+++ b/test/unit/ops/Transfer.t.sol
@@ -1,0 +1,221 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {BlockNumber, currentBlock} from "../../../src/BlockNumber.sol";
+import {Test} from "forge-std/Test.sol";
+import {Lib} from "../../utils/Lib.sol";
+import {EntityHashing} from "../../../src/EntityHashing.sol";
+import {EntityRegistry} from "../../../src/EntityRegistry.sol";
+
+contract TransferTest is Test, EntityRegistry {
+    address alice = makeAddr("alice");
+    address bob = makeAddr("bob");
+    address charlie = makeAddr("charlie");
+
+    BlockNumber expiresAt;
+    bytes32 testKey;
+
+    function _validateAttributes(EntityHashing.Attribute[] calldata) internal pure override {}
+
+    function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
+        return _create(op, currentBlock());
+    }
+
+    function doTransfer(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
+        return _transfer(op, currentBlock());
+    }
+
+    function setUp() public {
+        expiresAt = currentBlock() + BlockNumber.wrap(1000);
+
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory createOp = Lib.createOp("hello", "text/plain", attrs, expiresAt);
+        vm.prank(alice);
+        (testKey,) = this.doCreate(createOp);
+    }
+
+    // =========================================================================
+    // Validation — entity not found
+    // =========================================================================
+
+    function test_transfer_nonExistentEntity_reverts() public {
+        bytes32 bogus = keccak256("bogus");
+        EntityHashing.Op memory op = Lib.transferOp(bogus, bob);
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, bogus));
+        this.doTransfer(op);
+    }
+
+    // =========================================================================
+    // Validation — expired entity
+    // =========================================================================
+
+    function test_transfer_expiredEntity_reverts() public {
+        vm.roll(BlockNumber.unwrap(expiresAt) + 1);
+
+        EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
+        this.doTransfer(op);
+    }
+
+    function test_transfer_atExpiryBlock_reverts() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
+        this.doTransfer(op);
+    }
+
+    // =========================================================================
+    // Validation — not owner
+    // =========================================================================
+
+    function test_transfer_notOwner_reverts() public {
+        EntityHashing.Op memory op = Lib.transferOp(testKey, charlie);
+
+        vm.prank(bob);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NotOwner.selector, testKey, bob, alice));
+        this.doTransfer(op);
+    }
+
+    // =========================================================================
+    // Validation — zero address
+    // =========================================================================
+
+    function test_transfer_toZeroAddress_reverts() public {
+        EntityHashing.Op memory op = Lib.transferOp(testKey, address(0));
+
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.TransferToZeroAddress.selector, testKey));
+        this.doTransfer(op);
+    }
+
+    // =========================================================================
+    // State — commitment updates
+    // =========================================================================
+
+    function test_transfer_updatesOwner() public {
+        EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
+
+        vm.prank(alice);
+        this.doTransfer(op);
+
+        EntityHashing.Commitment memory c = getCommitment(testKey);
+        assertEq(c.owner, bob);
+    }
+
+    function test_transfer_updatesUpdatedAt() public {
+        vm.roll(block.number + 10);
+
+        EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
+        vm.prank(alice);
+        this.doTransfer(op);
+
+        EntityHashing.Commitment memory c = getCommitment(testKey);
+        assertEq(BlockNumber.unwrap(c.updatedAt), uint32(block.number));
+    }
+
+    function test_transfer_preservesCoreHashCreatorExpiry() public {
+        EntityHashing.Commitment memory before_ = getCommitment(testKey);
+
+        EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
+        vm.prank(alice);
+        this.doTransfer(op);
+
+        EntityHashing.Commitment memory after_ = getCommitment(testKey);
+        assertEq(after_.coreHash, before_.coreHash);
+        assertEq(after_.creator, before_.creator);
+        assertEq(BlockNumber.unwrap(after_.createdAt), BlockNumber.unwrap(before_.createdAt));
+        assertEq(BlockNumber.unwrap(after_.expiresAt), BlockNumber.unwrap(before_.expiresAt));
+    }
+
+    // =========================================================================
+    // State — new owner can operate
+    // =========================================================================
+
+    function test_transfer_newOwnerCanTransferAgain() public {
+        // alice → bob
+        EntityHashing.Op memory op1 = Lib.transferOp(testKey, bob);
+        vm.prank(alice);
+        this.doTransfer(op1);
+
+        // bob → charlie
+        EntityHashing.Op memory op2 = Lib.transferOp(testKey, charlie);
+        vm.prank(bob);
+        this.doTransfer(op2);
+
+        EntityHashing.Commitment memory c = getCommitment(testKey);
+        assertEq(c.owner, charlie);
+    }
+
+    function test_transfer_previousOwnerCannotOperate() public {
+        // alice → bob
+        EntityHashing.Op memory op1 = Lib.transferOp(testKey, bob);
+        vm.prank(alice);
+        this.doTransfer(op1);
+
+        // alice tries again
+        EntityHashing.Op memory op2 = Lib.transferOp(testKey, charlie);
+        vm.prank(alice);
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NotOwner.selector, testKey, alice, bob));
+        this.doTransfer(op2);
+    }
+
+    // =========================================================================
+    // State — returns correct key
+    // =========================================================================
+
+    function test_transfer_returnsEntityKey() public {
+        EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
+
+        vm.prank(alice);
+        (bytes32 returnedKey,) = this.doTransfer(op);
+
+        assertEq(returnedKey, testKey);
+    }
+
+    // =========================================================================
+    // Hash correctness
+    // =========================================================================
+
+    function test_transfer_entityHashUsesNewOwner() public {
+        EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
+
+        vm.prank(alice);
+        (, bytes32 entityHash_) = this.doTransfer(op);
+
+        EntityHashing.Commitment memory c = getCommitment(testKey);
+        bytes32 expected = _entityHash(c.coreHash, bob, c.updatedAt, c.expiresAt);
+        assertEq(entityHash_, expected);
+    }
+
+    function test_transfer_differentOwner_differentEntityHash() public {
+        // Get hash with alice as owner.
+        EntityHashing.Commitment memory beforeTransfer = getCommitment(testKey);
+        bytes32 hashAlice =
+            _entityHash(beforeTransfer.coreHash, alice, beforeTransfer.updatedAt, beforeTransfer.expiresAt);
+
+        // Transfer to bob.
+        EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
+        vm.prank(alice);
+        (, bytes32 hashBob) = this.doTransfer(op);
+
+        assertNotEq(hashAlice, hashBob);
+    }
+
+    // =========================================================================
+    // Event
+    // =========================================================================
+
+    function test_transfer_emitsEntityTransferred() public {
+        EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
+
+        vm.prank(alice);
+        vm.expectEmit(true, true, true, false);
+        emit EntityTransferred(testKey, alice, bob, bytes32(0));
+        this.doTransfer(op);
+    }
+}

--- a/test/unit/ops/Update.t.sol
+++ b/test/unit/ops/Update.t.sol
@@ -14,6 +14,9 @@ contract UpdateTest is Test, EntityRegistry {
     BlockNumber expiresAt;
     bytes32 testKey;
 
+    // Stub guard — tested separately in GuardEntityMutation.t.sol.
+    function _guardEntityMutation(bytes32, EntityHashing.Commitment storage, BlockNumber) internal view override {}
+
     // Calldata wrappers.
     function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
         return _create(op, currentBlock());
@@ -51,54 +54,6 @@ contract UpdateTest is Test, EntityRegistry {
     function _simpleUpdateOp() internal view returns (EntityHashing.Op memory) {
         EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
         return Lib.updateOp(testKey, "world", "text/plain", attrs);
-    }
-
-    // =========================================================================
-    // Validation — entity not found
-    // =========================================================================
-
-    function test_update_nonExistentEntity_reverts() public {
-        bytes32 bogus = keccak256("bogus");
-        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
-        EntityHashing.Op memory op = Lib.updateOp(bogus, "data", "text/plain", attrs);
-
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, bogus));
-        this.doUpdate(op);
-    }
-
-    // =========================================================================
-    // Validation — expired entity
-    // =========================================================================
-
-    function test_update_expiredEntity_reverts() public {
-        vm.roll(BlockNumber.unwrap(expiresAt) + 1);
-
-        EntityHashing.Op memory op = _simpleUpdateOp();
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
-        this.doUpdate(op);
-    }
-
-    function test_update_atExpiryBlock_reverts() public {
-        vm.roll(BlockNumber.unwrap(expiresAt));
-
-        EntityHashing.Op memory op = _simpleUpdateOp();
-        vm.prank(alice);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityExpired.selector, testKey, expiresAt));
-        this.doUpdate(op);
-    }
-
-    // =========================================================================
-    // Validation — not owner
-    // =========================================================================
-
-    function test_update_notOwner_reverts() public {
-        EntityHashing.Op memory op = _simpleUpdateOp();
-
-        vm.prank(bob);
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.NotOwner.selector, testKey, bob, alice));
-        this.doUpdate(op);
     }
 
     // =========================================================================

--- a/test/utils/Lib.sol
+++ b/test/utils/Lib.sol
@@ -48,6 +48,19 @@ library Lib {
         });
     }
 
+    function transferOp(bytes32 entityKey_, address newOwner_) internal pure returns (EntityHashing.Op memory) {
+        EntityHashing.Attribute[] memory empty = new EntityHashing.Attribute[](0);
+        return EntityHashing.Op({
+            opType: EntityHashing.TRANSFER,
+            entityKey: entityKey_,
+            payload: "",
+            contentType: "",
+            attributes: empty,
+            expiresAt: BlockNumber.wrap(0),
+            newOwner: newOwner_
+        });
+    }
+
     function extendOp(bytes32 entityKey_, BlockNumber expiresAt_) internal pure returns (EntityHashing.Op memory) {
         EntityHashing.Attribute[] memory empty = new EntityHashing.Attribute[](0);
         return EntityHashing.Op({


### PR DESCRIPTION
- **Added `TransferToZeroAddress` error** to `EntityHashing`: prevents burning entities by transferring to `address(0)`.

- **Added `EntityTransferred` event**: all three of entityKey, previousOwner, and newOwner are indexed for efficient filtering by either party. Includes entityHash.

- **Implemented `_transfer`**: same existence/expiry/ownership guards as other mutation ops. Rejects zero-address transfers. Updates `owner` and `updatedAt` (2 SSTOREs — owner in slot 1, updatedAt in slot 0). Recomputes `entityHash` from stored `coreHash` with new owner. `coreHash` preserved — transfer doesn't touch content.

- **14 unit tests** (`test/unit/ops/Transfer.t.sol`): entity not found, expired, at expiry block, not owner, zero address, owner updates, updatedAt advances, coreHash/creator/expiry preserved, chain transfer (alice→bob→charlie), previous owner locked out after transfer, returns correct key, entityHash uses new owner, different owner produces different hash, event emission.

- **Added `Lib.transferOp`** helper for constructing TRANSFER ops in tests.