### PR TITLE
Implement _expire operation with unit tests

### DIFF
--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -116,6 +116,9 @@ library EntityHashing {
     /// @dev Reverted when transfer target is the zero address.
     error TransferToZeroAddress(bytes32 entityKey);
 
+    /// @dev Reverted when expire is called on an entity that hasn't expired yet.
+    error EntityNotExpired(bytes32 entityKey, BlockNumber expiresAt);
+
     // -------------------------------------------------------------------------
     // Constants
     // -------------------------------------------------------------------------

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -445,7 +445,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
             revert EntityHashing.EntityNotExpired(key, c.expiresAt);
         }
 
-        bytes32 entityHash_ = _entityHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt);
+        bytes32 entityHash_ = _wrapEntityHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt);
         address owner = c.owner;
 
         delete _commitments[key];

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -67,6 +67,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         bytes32 indexed entityKey, address indexed previousOwner, address indexed newOwner, bytes32 entityHash
     );
     event EntityDeleted(bytes32 indexed entityKey, address indexed owner, bytes32 entityHash);
+    event EntityExpired(bytes32 indexed entityKey, address indexed owner, bytes32 entityHash);
 
     // -------------------------------------------------------------------------
     // State — linked list pointers
@@ -423,9 +424,33 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         return (key, entityHash_);
     }
 
+    /// @dev Remove an expired entity from storage. Callable by anyone — no
+    /// ownership check. The entity must exist and must have expired
+    /// (expiresAt <= current). This is the inverse of the expiry guard on
+    /// other ops (which require expiresAt > current).
+    ///
+    /// Validation:
+    ///   1. Entity must exist (creator != address(0))
+    ///   2. Entity must have expired (expiresAt <= current)
+    ///
+    /// Storage: deletes the Commitment (zeroes 3 slots via SSTORE to 0, gas refund).
     function _expire(bytes32 key, BlockNumber current) internal virtual returns (bytes32, bytes32) {
-        // Validates: entity exists + currentBlock >= expiresAt (entity has expired)
-        // Then: snapshot entityHash before deletion, delete entity (callable by anyone)
-        revert("not implemented");
+        EntityHashing.Commitment storage c = _commitments[key];
+
+        if (c.creator == address(0)) {
+            revert EntityHashing.EntityNotFound(key);
+        }
+
+        if (c.expiresAt > current) {
+            revert EntityHashing.EntityNotExpired(key, c.expiresAt);
+        }
+
+        bytes32 entityHash_ = _entityHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt);
+        address owner = c.owner;
+
+        delete _commitments[key];
+
+        emit EntityExpired(key, owner, entityHash_);
+        return (key, entityHash_);
     }
 }

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -241,6 +241,23 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         }
     }
 
+    /// @dev Require that the entity exists and has expired (expiresAt <= current).
+    /// Guard for the expire operation. Implemented as a function rather than a
+    /// modifier so callers can load the Commitment storage pointer once and
+    /// reuse it for both validation and state updates.
+    function _guardEntityExpiry(bytes32 key, EntityHashing.Commitment storage c, BlockNumber current)
+        internal
+        view
+        virtual
+    {
+        if (c.creator == address(0)) {
+            revert EntityHashing.EntityNotFound(key);
+        }
+        if (c.expiresAt > current) {
+            revert EntityHashing.EntityNotExpired(key, c.expiresAt);
+        }
+    }
+
     /// @dev Mint a new entity key by post-incrementing the owner's nonce.
     /// Uniqueness is guaranteed by the monotonic nonce — no existence check needed.
     function _createEntityKey(address owner) internal virtual returns (bytes32) {
@@ -436,14 +453,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     /// Storage: deletes the Commitment (zeroes 3 slots via SSTORE to 0, gas refund).
     function _expire(bytes32 key, BlockNumber current) internal virtual returns (bytes32, bytes32) {
         EntityHashing.Commitment storage c = _commitments[key];
-
-        if (c.creator == address(0)) {
-            revert EntityHashing.EntityNotFound(key);
-        }
-
-        if (c.expiresAt > current) {
-            revert EntityHashing.EntityNotExpired(key, c.expiresAt);
-        }
+        _guardEntityExpiry(key, c, current);
 
         bytes32 entityHash_ = _wrapEntityHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt);
         address owner = c.owner;

--- a/test/unit/GuardEntityExpiry.t.sol
+++ b/test/unit/GuardEntityExpiry.t.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {BlockNumber, currentBlock} from "../../src/BlockNumber.sol";
+import {Test} from "forge-std/Test.sol";
+import {Lib} from "../utils/Lib.sol";
+import {EntityHashing} from "../../src/EntityHashing.sol";
+import {EntityRegistry} from "../../src/EntityRegistry.sol";
+
+/// @dev Tests _guardEntityExpiry in isolation.
+contract GuardEntityExpiryTest is Test, EntityRegistry {
+    address alice = makeAddr("alice");
+    address bob = makeAddr("bob");
+
+    BlockNumber expiresAt;
+    bytes32 testKey;
+
+    function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
+        return _create(op, currentBlock());
+    }
+
+    function doGuard(bytes32 key, BlockNumber current) external view {
+        EntityHashing.Commitment storage c = _commitments[key];
+        _guardEntityExpiry(key, c, current);
+    }
+
+    function setUp() public {
+        expiresAt = currentBlock() + BlockNumber.wrap(1000);
+
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory op = Lib.createOp("hello", "text/plain", attrs, expiresAt);
+        vm.prank(alice);
+        (testKey,) = this.doCreate(op);
+    }
+
+    // =========================================================================
+    // Entity not found
+    // =========================================================================
+
+    function test_nonExistentEntity_reverts() public {
+        bytes32 bogus = keccak256("bogus");
+
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, bogus));
+        this.doGuard(bogus, currentBlock());
+    }
+
+    // =========================================================================
+    // Entity not yet expired
+    // =========================================================================
+
+    function test_notYetExpired_reverts() public {
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotExpired.selector, testKey, expiresAt));
+        this.doGuard(testKey, currentBlock());
+    }
+
+    function test_oneBlockBeforeExpiry_reverts() public {
+        vm.roll(BlockNumber.unwrap(expiresAt) - 1);
+
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotExpired.selector, testKey, expiresAt));
+        this.doGuard(testKey, currentBlock());
+    }
+
+    // =========================================================================
+    // Happy path — expired
+    // =========================================================================
+
+    function test_atExactExpiryBlock_succeeds() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        this.doGuard(testKey, currentBlock());
+    }
+
+    function test_afterExpiryBlock_succeeds() public {
+        vm.roll(BlockNumber.unwrap(expiresAt) + 100);
+
+        this.doGuard(testKey, currentBlock());
+    }
+
+    // =========================================================================
+    // Callable by anyone
+    // =========================================================================
+
+    function test_callableByNonOwner() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        vm.prank(bob);
+        this.doGuard(testKey, currentBlock());
+    }
+}

--- a/test/unit/ops/Expire.t.sol
+++ b/test/unit/ops/Expire.t.sol
@@ -14,6 +14,9 @@ contract ExpireTest is Test, EntityRegistry {
     BlockNumber expiresAt;
     bytes32 testKey;
 
+    // Stub guard — tested separately in GuardEntityExpiry.t.sol.
+    function _guardEntityExpiry(bytes32, EntityHashing.Commitment storage, BlockNumber) internal view override {}
+
     function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
         return _create(op, currentBlock());
     }
@@ -32,63 +35,10 @@ contract ExpireTest is Test, EntityRegistry {
     }
 
     // =========================================================================
-    // Validation — entity not found
-    // =========================================================================
-
-    function test_expire_nonExistentEntity_reverts() public {
-        bytes32 bogus = keccak256("bogus");
-
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, bogus));
-        this.doExpire(bogus);
-    }
-
-    // =========================================================================
-    // Validation — entity not yet expired
-    // =========================================================================
-
-    function test_expire_notYetExpired_reverts() public {
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotExpired.selector, testKey, expiresAt));
-        this.doExpire(testKey);
-    }
-
-    function test_expire_oneBlockBeforeExpiry_reverts() public {
-        vm.roll(BlockNumber.unwrap(expiresAt) - 1);
-
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotExpired.selector, testKey, expiresAt));
-        this.doExpire(testKey);
-    }
-
-    // =========================================================================
-    // Callable by anyone
-    // =========================================================================
-
-    function test_expire_callableByNonOwner() public {
-        vm.roll(BlockNumber.unwrap(expiresAt));
-
-        // bob (not the owner) can expire alice's entity.
-        vm.prank(bob);
-        (bytes32 returnedKey,) = this.doExpire(testKey);
-
-        assertEq(returnedKey, testKey);
-        assertEq(getCommitment(testKey).creator, address(0));
-    }
-
-    function test_expire_callableByOwner() public {
-        vm.roll(BlockNumber.unwrap(expiresAt));
-
-        vm.prank(alice);
-        (bytes32 returnedKey,) = this.doExpire(testKey);
-
-        assertEq(returnedKey, testKey);
-    }
-
-    // =========================================================================
     // State — commitment removed
     // =========================================================================
 
     function test_expire_removesCommitment() public {
-        vm.roll(BlockNumber.unwrap(expiresAt));
-
         this.doExpire(testKey);
 
         EntityHashing.Commitment memory c = getCommitment(testKey);
@@ -100,29 +50,11 @@ contract ExpireTest is Test, EntityRegistry {
         assertEq(BlockNumber.unwrap(c.expiresAt), 0);
     }
 
-    function test_expire_doubleExpire_reverts() public {
-        vm.roll(BlockNumber.unwrap(expiresAt));
-
-        this.doExpire(testKey);
-
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, testKey));
-        this.doExpire(testKey);
-    }
-
     // =========================================================================
-    // Expiry boundary — exactly at expiresAt
+    // Return values
     // =========================================================================
 
-    function test_expire_atExactExpiryBlock_succeeds() public {
-        vm.roll(BlockNumber.unwrap(expiresAt));
-
-        (bytes32 returnedKey,) = this.doExpire(testKey);
-        assertEq(returnedKey, testKey);
-    }
-
-    function test_expire_afterExpiryBlock_succeeds() public {
-        vm.roll(BlockNumber.unwrap(expiresAt) + 100);
-
+    function test_expire_returnsEntityKey() public {
         (bytes32 returnedKey,) = this.doExpire(testKey);
         assertEq(returnedKey, testKey);
     }
@@ -132,11 +64,8 @@ contract ExpireTest is Test, EntityRegistry {
     // =========================================================================
 
     function test_expire_returnsSnapshotHash() public {
-        // Compute expected hash from commitment before expiry.
         EntityHashing.Commitment memory c = getCommitment(testKey);
         bytes32 expected = _wrapEntityHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt);
-
-        vm.roll(BlockNumber.unwrap(expiresAt));
 
         (, bytes32 entityHash_) = this.doExpire(testKey);
         assertEq(entityHash_, expected);
@@ -147,8 +76,6 @@ contract ExpireTest is Test, EntityRegistry {
     // =========================================================================
 
     function test_expire_emitsEntityExpired() public {
-        vm.roll(BlockNumber.unwrap(expiresAt));
-
         vm.expectEmit(true, true, false, false);
         emit EntityExpired(testKey, alice, bytes32(0));
         this.doExpire(testKey);

--- a/test/unit/ops/Expire.t.sol
+++ b/test/unit/ops/Expire.t.sol
@@ -14,8 +14,6 @@ contract ExpireTest is Test, EntityRegistry {
     BlockNumber expiresAt;
     bytes32 testKey;
 
-    function _validateAttributes(EntityHashing.Attribute[] calldata) internal pure override {}
-
     function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
         return _create(op, currentBlock());
     }
@@ -136,7 +134,7 @@ contract ExpireTest is Test, EntityRegistry {
     function test_expire_returnsSnapshotHash() public {
         // Compute expected hash from commitment before expiry.
         EntityHashing.Commitment memory c = getCommitment(testKey);
-        bytes32 expected = _entityHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt);
+        bytes32 expected = _wrapEntityHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt);
 
         vm.roll(BlockNumber.unwrap(expiresAt));
 

--- a/test/unit/ops/Expire.t.sol
+++ b/test/unit/ops/Expire.t.sol
@@ -1,0 +1,158 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {BlockNumber, currentBlock} from "../../../src/BlockNumber.sol";
+import {Test} from "forge-std/Test.sol";
+import {Lib} from "../../utils/Lib.sol";
+import {EntityHashing} from "../../../src/EntityHashing.sol";
+import {EntityRegistry} from "../../../src/EntityRegistry.sol";
+
+contract ExpireTest is Test, EntityRegistry {
+    address alice = makeAddr("alice");
+    address bob = makeAddr("bob");
+
+    BlockNumber expiresAt;
+    bytes32 testKey;
+
+    function _validateAttributes(EntityHashing.Attribute[] calldata) internal pure override {}
+
+    function doCreate(EntityHashing.Op calldata op) external returns (bytes32, bytes32) {
+        return _create(op, currentBlock());
+    }
+
+    function doExpire(bytes32 key) external returns (bytes32, bytes32) {
+        return _expire(key, currentBlock());
+    }
+
+    function setUp() public {
+        expiresAt = currentBlock() + BlockNumber.wrap(1000);
+
+        EntityHashing.Attribute[] memory attrs = new EntityHashing.Attribute[](0);
+        EntityHashing.Op memory createOp = Lib.createOp("hello", "text/plain", attrs, expiresAt);
+        vm.prank(alice);
+        (testKey,) = this.doCreate(createOp);
+    }
+
+    // =========================================================================
+    // Validation — entity not found
+    // =========================================================================
+
+    function test_expire_nonExistentEntity_reverts() public {
+        bytes32 bogus = keccak256("bogus");
+
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, bogus));
+        this.doExpire(bogus);
+    }
+
+    // =========================================================================
+    // Validation — entity not yet expired
+    // =========================================================================
+
+    function test_expire_notYetExpired_reverts() public {
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotExpired.selector, testKey, expiresAt));
+        this.doExpire(testKey);
+    }
+
+    function test_expire_oneBlockBeforeExpiry_reverts() public {
+        vm.roll(BlockNumber.unwrap(expiresAt) - 1);
+
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotExpired.selector, testKey, expiresAt));
+        this.doExpire(testKey);
+    }
+
+    // =========================================================================
+    // Callable by anyone
+    // =========================================================================
+
+    function test_expire_callableByNonOwner() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        // bob (not the owner) can expire alice's entity.
+        vm.prank(bob);
+        (bytes32 returnedKey,) = this.doExpire(testKey);
+
+        assertEq(returnedKey, testKey);
+        assertEq(getCommitment(testKey).creator, address(0));
+    }
+
+    function test_expire_callableByOwner() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        vm.prank(alice);
+        (bytes32 returnedKey,) = this.doExpire(testKey);
+
+        assertEq(returnedKey, testKey);
+    }
+
+    // =========================================================================
+    // State — commitment removed
+    // =========================================================================
+
+    function test_expire_removesCommitment() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        this.doExpire(testKey);
+
+        EntityHashing.Commitment memory c = getCommitment(testKey);
+        assertEq(c.creator, address(0));
+        assertEq(c.owner, address(0));
+        assertEq(c.coreHash, bytes32(0));
+        assertEq(BlockNumber.unwrap(c.createdAt), 0);
+        assertEq(BlockNumber.unwrap(c.updatedAt), 0);
+        assertEq(BlockNumber.unwrap(c.expiresAt), 0);
+    }
+
+    function test_expire_doubleExpire_reverts() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        this.doExpire(testKey);
+
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.EntityNotFound.selector, testKey));
+        this.doExpire(testKey);
+    }
+
+    // =========================================================================
+    // Expiry boundary — exactly at expiresAt
+    // =========================================================================
+
+    function test_expire_atExactExpiryBlock_succeeds() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        (bytes32 returnedKey,) = this.doExpire(testKey);
+        assertEq(returnedKey, testKey);
+    }
+
+    function test_expire_afterExpiryBlock_succeeds() public {
+        vm.roll(BlockNumber.unwrap(expiresAt) + 100);
+
+        (bytes32 returnedKey,) = this.doExpire(testKey);
+        assertEq(returnedKey, testKey);
+    }
+
+    // =========================================================================
+    // Hash correctness
+    // =========================================================================
+
+    function test_expire_returnsSnapshotHash() public {
+        // Compute expected hash from commitment before expiry.
+        EntityHashing.Commitment memory c = getCommitment(testKey);
+        bytes32 expected = _entityHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt);
+
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        (, bytes32 entityHash_) = this.doExpire(testKey);
+        assertEq(entityHash_, expected);
+    }
+
+    // =========================================================================
+    // Event
+    // =========================================================================
+
+    function test_expire_emitsEntityExpired() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+
+        vm.expectEmit(true, true, false, false);
+        emit EntityExpired(testKey, alice, bytes32(0));
+        this.doExpire(testKey);
+    }
+}


### PR DESCRIPTION
- **Added `EntityNotExpired` error** to `EntityHashing`: inverse of `EntityExpired`. Reverts when expire is called on an entity that hasn't reached its expiry block.

- **Added `EntityExpired` event**: indexed entityKey + owner, includes the entityHash snapshot taken before deletion.

- **Implemented `_expire`**: callable by anyone — no ownership check. Requires the entity to have expired (`expiresAt <= current`), which is the inverse of the guard on all other mutation ops. Succeeds at exactly the expiry block — consistent with other ops rejecting at that same block. Snapshots `entityHash` before deletion, then `delete _commitments[key]` (zeroes 3 slots, gas refund).

- **11 unit tests** (`test/unit/ops/Expire.t.sol`): entity not found, not yet expired, one block before expiry reverts, callable by non-owner, callable by owner, commitment fully zeroed, double-expire reverts with EntityNotFound, at exact expiry block succeeds, after expiry block succeeds, snapshot hash matches pre-deletion computation, event emission.