### PR TITLE
Reserve 0 as UNINITIALIZED sentinel for opType and ATTR constants

### DIFF
--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -103,6 +103,9 @@ library EntityHashing {
     error AttributesNotSorted();
     error InvalidValueLength(bytes32 name, uint8 valueType, uint256 length);
     error InvalidValueType(bytes32 name, uint8 valueType);
+    /// @dev Reverted when opType is unrecognized (including 0 / uninitialized).
+    error InvalidOpType(uint8 opType);
+
     error ExpiryInPast(BlockNumber expiresAt, BlockNumber currentBlock);
     error TooManyAttributes(uint256 count, uint256 maxCount);
 

--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -21,12 +21,17 @@ library EntityHashing {
     // Type declarations
     // -------------------------------------------------------------------------
 
-    uint8 public constant CREATE = 0;
-    uint8 public constant UPDATE = 1;
-    uint8 public constant EXTEND = 2;
-    uint8 public constant TRANSFER = 3;
-    uint8 public constant DELETE = 4;
-    uint8 public constant EXPIRE = 5;
+    /// @dev Sentinel value for uninitialized or invalid opType / valueType.
+    /// Solidity zero-initializes uint8 fields, so any Op or Attribute with
+    /// an unset discriminator will carry this value and be rejected.
+    uint8 public constant UNINITIALIZED = 0;
+
+    uint8 public constant CREATE = 1;
+    uint8 public constant UPDATE = 2;
+    uint8 public constant EXTEND = 3;
+    uint8 public constant TRANSFER = 4;
+    uint8 public constant DELETE = 5;
+    uint8 public constant EXPIRE = 6;
 
     /// @dev Batch element: describes a single entity operation within an
     /// `execute()` call. Fields are interpreted according to `opType`:
@@ -49,9 +54,9 @@ library EntityHashing {
     /// @dev Discriminator for attribute value types. Encoded into the
     /// attribute hash so that different types with identical raw bytes
     /// produce distinct hashes.
-    uint8 public constant ATTR_UINT = 0;
-    uint8 public constant ATTR_STRING = 1;
-    uint8 public constant ATTR_ENTITY_KEY = 2;
+    uint8 public constant ATTR_UINT = 1;
+    uint8 public constant ATTR_STRING = 2;
+    uint8 public constant ATTR_ENTITY_KEY = 3;
 
     /// @dev A typed key-value pair attached to an entity. The `name` is a
     /// bytes32-packed UTF-8 identifier (left-aligned, zero-padded).

--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -137,7 +137,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
             } else if (opType == EntityHashing.EXPIRE) {
                 (key, entityHash_) = _expire(ops[opSeq].entityKey, current);
             } else {
-                // TODO should not reach here
+                revert EntityHashing.InvalidOpType(opType);
             }
 
             hash = EntityHashing.chainOp(hash, opType, key, entityHash_);

--- a/test/unit/hashing/AttributeHash.t.sol
+++ b/test/unit/hashing/AttributeHash.t.sol
@@ -187,10 +187,21 @@ contract AttributeHashTest is Test, EntityRegistry {
         );
     }
 
-    function test_attributeHash_revertsOnInvalidValueType() public {
+    function test_attributeHash_revertsOnUninitializedValueType() public {
+        EntityHashing.Attribute memory attr = EntityHashing.Attribute({
+            name: Lib.packName("bad"), valueType: EntityHashing.UNINITIALIZED, value: abi.encode(uint256(1))
+        });
+        vm.expectRevert(
+            abi.encodeWithSelector(EntityHashing.InvalidValueType.selector, attr.name, EntityHashing.UNINITIALIZED)
+        );
+        _hashOne(attr);
+    }
+
+    function test_attributeHash_revertsOnValueTypeAboveRange() public {
+        uint8 aboveRange = EntityHashing.ATTR_ENTITY_KEY + 1;
         EntityHashing.Attribute memory attr =
-            EntityHashing.Attribute({name: Lib.packName("bad"), valueType: 99, value: hex"00"});
-        vm.expectRevert(abi.encodeWithSelector(EntityHashing.InvalidValueType.selector, attr.name, 99));
+            EntityHashing.Attribute({name: Lib.packName("bad"), valueType: aboveRange, value: hex"00"});
+        vm.expectRevert(abi.encodeWithSelector(EntityHashing.InvalidValueType.selector, attr.name, aboveRange));
         _hashOne(attr);
     }
 


### PR DESCRIPTION
Fixes #27

- Increment opType constants (CREATE..EXPIRE) to start at 1 instead of 0
- Increment attribute type constants (ATTR_UINT..ATTR_ENTITY_KEY) to start at 1
- Add `UNINITIALIZED = 0` sentinel constant
- Add `InvalidOpType(uint8)` error and revert in `execute()` dispatch for unrecognized opType
- Add tests for uninitialized and out-of-range attribute valueType

This slightly covers #21 also but tests will be left for a seperate PR