### PR TITLE
Ident32: validated bytes32 identifier charset for attribute names

### DIFF
--- a/docs/ident32-encoding.md
+++ b/docs/ident32-encoding.md
@@ -1,0 +1,201 @@
+# Ident32: Validated bytes32 Identifiers
+
+| Property | Value |
+|----------|-------|
+| **Status** | Design |
+| **Source** | `src/Ident32.sol` (to be created) |
+| **Depends on** | [ADR-API-004](ADR-API-004.md) (String Field Encoding) |
+| **Created** | April 2026 |
+
+## Problem
+
+Attribute names (`attr.name` in the `Attribute` struct) are `bytes32` values that currently receive no charset validation. The `attributeHash` function in `EntityHashing.sol` enforces sorted order and uniqueness, but accepts any 32-byte value — including uppercase, control characters, or arbitrary binary data.
+
+This creates three problems:
+
+1. **Case ambiguity**: `"Count"` and `"count"` are different `bytes32` values that hash differently. Two entities with semantically identical attributes produce different core hashes. The off-chain indexer must either reject one or treat them as distinct, with no protocol-level guidance.
+
+2. **Non-determinism across SDKs**: A JavaScript SDK that lowercases attribute names and a Python SDK that doesn't will produce incompatible entities. The bug is silent — both produce valid transactions that the contract accepts.
+
+3. **Garbage names**: Binary data, control characters, or emoji in attribute names pass validation today. This pollutes the index namespace and makes debugging harder.
+
+Per [ADR-API-004](ADR-API-004.md), attribute names are **identifiers** — lowercase ASCII, maximum 32 bytes.
+
+## Design
+
+### Type
+
+The attribute name stays as `bytes32` in the `Attribute` struct — no wrapper struct. Attribute names are already packed as left-aligned, zero-padded `bytes32` values throughout the codebase. Introducing a wrapper struct would change the `Attribute` struct layout, the EIP-712 `ATTRIBUTE_TYPEHASH`, and every test that constructs attributes. The cost exceeds the benefit for a field that is always a single word.
+
+Instead, validation is a free function that operates on a bare `bytes32`:
+
+```solidity
+function validateIdent32(bytes32 value) pure returns (uint256 len);
+```
+
+### Charset
+
+Attribute names are identifiers, not free-form text. The charset should be restrictive enough to prevent ambiguity while permitting readable, conventional naming patterns. Three options considered:
+
+| Option | Valid chars | Example names | Allows |
+|---|---|---|---|
+| **A. `LOWER_PRINTABLE_ASCII`** | 0x20–0x7E minus uppercase | `content.length`, `a=b`, `x;y` | Space, `;`, `=`, `@`, `"`, etc. |
+| **B. `MIME_TOKEN`** | RFC 2045 token chars, lowercase | `content.length`, `x-custom`, `tag!` | `.`, `-`, `_`, `!`, `#`, `%`, `+`, `^`, `'`, `*`, `` ` ``, `{`, `\|`, `}`, `~` |
+| **C. Identifier charset** (recommended) | `a-z 0-9 . - _` | `content.length`, `x-custom`, `tag_v2` | Only the three separators that appear in real-world identifier conventions |
+
+**Option A is too broad.** Characters like `;`, `=`, `@`, `"`, and space have no business in an identifier. They create parsing ambiguity in query languages, log output, and URL parameters. An attribute named `a=b` or `key;value` would be valid, which is confusing.
+
+**Option B is narrower but still noisy.** MIME token chars include `!`, `#`, `%`, `'`, `*`, `^`, `` ` ``, `{`, `|`, `}`, `~` — characters that are technically allowed but never appear in real identifier conventions. Permitting them adds no practical value while making the namespace harder to reason about.
+
+**Option C is the tightest useful set.** Lowercase alphanumeric plus three separators covers every conventional naming pattern:
+
+| Pattern | Example | Separator |
+|---|---|---|
+| Flat | `count`, `status` | none |
+| Dotted namespace | `content.length`, `http.status` | `.` |
+| Kebab-case | `x-custom`, `created-at` | `-` |
+| Snake-case | `tag_v2`, `file_size` | `_` |
+
+No other separator carries its weight. `/` implies hierarchy (use dotted namespace instead), `:` implies key-value (confusing for a field that IS a key), and everything else is noise.
+
+The bitmap for option C:
+
+```
+IDENT_CHARSET:
+  a-z  (0x61–0x7A)  — 26 chars
+  0-9  (0x30–0x39)  — 10 chars
+  .    (0x2E)        — dotted namespace
+  -    (0x2D)        — kebab-case
+  _    (0x5F)        — snake_case
+```
+
+This is a new bitmap defined in `Ident32.sol`, not shared from `Mime128.sol`. The charsets serve different purposes — MIME tokens follow an RFC, identifiers follow naming conventions — and coupling them would be a false economy.
+
+### Validation rules
+
+1. **Non-empty**: at least one non-zero byte. Reverts with `Ident32Empty()`.
+2. **Leading byte**: byte 0 must be `a-z`. Digits and separators are not valid as a leading character — `123count`, `.hidden`, `-flag`, `_private` are rejected. Reverts with `Ident32InvalidByte(0, value)`.
+3. **Charset**: every subsequent non-zero byte must be in `IDENT_CHARSET` (`a-z`, `0-9`, `.`, `-`, `_`). Reverts with `Ident32InvalidByte(position, value)`.
+4. **Left-aligned**: once a zero byte is encountered, all remaining bytes must also be zero (no embedded nulls). Reverts with `Ident32InvalidByte(position, 0x00)`.
+5. **Returns length**: the number of non-zero bytes (1–32).
+
+The leading-byte check is a single comparison before the loop — ~6 gas overhead.
+
+No state machine needed — attribute names have no internal structure. A single linear scan suffices.
+
+### Integration point
+
+Validation is called in `EntityHashing.attributeHash()`, the existing single-pass function that already validates sort order, uniqueness, value types, and value lengths. Adding `validateIdent32(attr.name)` at the top of this function means every attribute name in every entity operation is validated — CREATE, UPDATE, and any future operation that includes attributes.
+
+```solidity
+function attributeHash(bytes32 prevName, bytes32 chain, Attribute calldata attr)
+    internal
+    pure
+    returns (bytes32, bytes32)
+{
+    validateIdent32(attr.name);       // ← new
+    if (attr.name <= prevName) revert AttributesNotSorted();
+    // ... rest unchanged
+}
+```
+
+This placement means validation runs before the sort check, producing clearer errors — "invalid byte at position 3" rather than a misleading "not sorted" when the real problem is an uppercase name.
+
+### Gas cost
+
+Single `bytes32` — 32 bytes maximum, one word:
+
+| Operation | Gas |
+|---|---|
+| Leading byte check | ~6 gas |
+| Bitmap check per byte | ~9 gas (shift + mask + branch) |
+| Zero-byte tail check | ~3 gas/byte |
+| Typical 5–10 char name | ~50–100 gas |
+| Maximum 32 chars | ~320 gas |
+
+Attribute hashing already costs ~500 gas per attribute (abi.encode + keccak256). Validation adds ~15–20% overhead per attribute. For a typical entity with 3–5 attributes, total added cost is 150–500 gas — negligible relative to the calldata and storage costs of the operation.
+
+### Functions
+
+| Function | Signature | Purpose |
+|---|---|---|
+| `validateIdent32` | `(bytes32) pure returns (uint256 len)` | Charset + leading byte + non-empty + no embedded nulls. Returns length. |
+| `encodeIdent32` | `(string memory) pure returns (bytes32)` | String → left-aligned bytes32. Reverts if empty or >32 bytes. |
+| `decodeIdent32` | `(bytes32) pure returns (string memory)` | bytes32 → string. Strips trailing zeros. |
+
+`encodeIdent32` replaces the test-only `Lib.packName` helper with a production function. `decodeIdent32` is the inverse for off-chain readability (view functions, event indexing).
+
+### Files
+
+| File | Change |
+|---|---|
+| `src/Ident32.sol` | New — free functions: `validateIdent32`, `encodeIdent32`, `decodeIdent32`, bitmap constant, errors |
+| `src/EntityHashing.sol` | Add `validateIdent32(attr.name)` call in `attributeHash` |
+| `test/utils/Lib.sol` | Replace `packName` body with `encodeIdent32` delegation |
+| `test/unit/Ident32.t.sol` | New — validation tests (charset, leading byte, empty, embedded nulls, boundary bytes, all uppercase rejected) |
+| `test/unit/hashing/AttributeHash.t.sol` | Fuzz tests need `vm.assume` for valid charset; new tests for uppercase/invalid name rejection |
+
+### Errors
+
+```solidity
+error Ident32Empty();
+error Ident32TooLong(uint256 length);
+error Ident32InvalidByte(uint256 position, bytes1 value);
+```
+
+### Comparison with OpenZeppelin ShortStrings
+
+OpenZeppelin provides [`ShortStrings.sol`](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/ShortStrings.sol) — a `bytes32` string encoding used primarily for EIP-712 domain names and versions. It solves a different problem, but the comparison is instructive.
+
+**How OZ ShortString works**: Packs a string of up to 31 bytes into a `bytes32` using `type ShortString is bytes32`. The string data occupies the high 31 bytes (left-aligned), and the lowest byte stores the length. Strings longer than 31 bytes fall back to a separate `string storage` slot, with a sentinel value (`0xFF` in the length byte) indicating the fallback.
+
+| Aspect | OZ ShortString | Ident32 |
+|---|---|---|
+| **Max length** | 31 bytes (1 byte reserved for length) | 32 bytes (full word) |
+| **Length tracking** | Stored in lowest byte of the word | Derived by scanning for trailing zeros |
+| **Type safety** | `type ShortString is bytes32` (UDT) | Bare `bytes32` (no wrapper) |
+| **Charset validation** | None — accepts any bytes | Bitmap-validated identifier charset (`a-z 0-9 . - _`) |
+| **Leading char rule** | None | Must be `a-z` |
+| **Fallback for long strings** | Writes to `string storage` + sentinel | Reverts — no fallback |
+| **Primary use case** | Immutable config strings (EIP-712 name/version) | Validated identifiers in calldata (attribute names) |
+
+**Why not use OZ ShortString:**
+
+1. **Length byte costs a slot.** OZ reserves the lowest byte for length, capping content at 31 bytes. Attribute names are already left-aligned `bytes32` with trailing zeros throughout the codebase — the length is implicit. Switching to OZ encoding would waste a byte and require re-encoding every existing name, changing the EIP-712 `ATTRIBUTE_TYPEHASH`, and breaking hash compatibility.
+
+2. **No charset validation.** OZ ShortString accepts any byte sequence. The entire point of our validation is rejecting uppercase, control chars, and non-identifier characters. We'd need to add validation on top of OZ anyway, gaining nothing from the dependency.
+
+3. **Fallback mechanism is unnecessary.** Attribute names that don't fit in 32 bytes are invalid — they should revert, not silently spill to storage. The fallback pattern adds complexity for a code path we explicitly forbid.
+
+4. **Type wrapper conflicts with existing layout.** The `Attribute` struct uses bare `bytes32 name`. Wrapping it in `type ShortString is bytes32` would change the struct's ABI encoding, the typehash, and every call site. The wrapper provides type safety but at a high migration cost for a field that is unambiguous in context.
+
+**What we take from OZ:** The left-aligned, zero-padded encoding is the same — OZ just adds a length byte we don't need. The `encodeIdent32` / `decodeIdent32` API mirrors OZ's `toShortString` / `toString` naming convention.
+
+### Interaction with existing sort validation
+
+The sort check in `attributeHash` (`attr.name <= prevName`) operates on raw `bytes32` comparison. Since the identifier charset preserves byte ordering (lowercase `a` < `b` < `z`, digits sort before letters, separators sort between digits and letters), the existing lexicographic sort on `bytes32` produces the same ordering as ASCII string comparison. No change needed.
+
+### Test plan
+
+**Ident32.t.sol** (new):
+- Encode/decode roundtrip for various lengths (1, 16, 31, 32 bytes)
+- Encode revert on empty, >32 bytes
+- Validate accepts lowercase alpha (`a-z`), digits (`0-9`), dot, hyphen, underscore
+- Validate rejects leading digit (`0count`), leading dot (`.hidden`), leading hyphen (`-flag`), leading underscore (`_private`)
+- Validate accepts leading lowercase letter
+- Validate rejects each uppercase letter (A–Z) in any position
+- Validate rejects space, control chars, DEL, high bytes
+- Validate rejects all printable ASCII outside the identifier set (`!`, `@`, `#`, `/`, `:`, `;`, etc.)
+- Validate rejects embedded null (e.g., `"ab\0cd"`)
+- Validate returns correct length
+- Bitmap spot checks: every valid char set, every adjacent invalid char unset
+
+**AttributeHash.t.sol** (updated):
+- Existing fuzz tests add `vm.assume` to constrain names to valid charset
+- New test: uppercase attribute name reverts with `Ident32InvalidByte`
+- New test: control char in name reverts
+- New test: valid lowercase name passes through to hash
+
+## Open questions
+
+None currently outstanding.

--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -102,33 +102,30 @@ library EntityHashing {
 
     /// @dev Reverted when `execute()` is called with an empty ops array.
     error EmptyBatch();
+    /// @dev Reverted when attributes are not in strictly ascending name order.
     error AttributesNotSorted();
+    /// @dev Reverted when an attribute value has the wrong byte length for its type.
     error InvalidValueLength(Ident32 name, uint8 valueType, uint256 length);
+    /// @dev Reverted when an attribute's valueType is unrecognized (including 0 / uninitialized).
     error InvalidValueType(Ident32 name, uint8 valueType);
     /// @dev Reverted when opType is unrecognized (including 0 / uninitialized).
     error InvalidOpType(uint8 opType);
-
+    /// @dev Reverted when expiresAt is not strictly after the current block.
     error ExpiryInPast(BlockNumber expiresAt, BlockNumber currentBlock);
+    /// @dev Reverted when the attribute count exceeds MAX_ATTRIBUTES.
     error TooManyAttributes(uint256 count, uint256 maxCount);
-
     /// @dev Reverted when an entity key does not exist in storage.
     error EntityNotFound(bytes32 entityKey);
-
     /// @dev Reverted when the caller is not the entity owner.
     error NotOwner(bytes32 entityKey, address caller, address owner);
-
     /// @dev Reverted when an operation targets an expired entity.
     error EntityExpired(bytes32 entityKey, BlockNumber expiresAt);
-
     /// @dev Reverted when new expiresAt is not strictly greater than current.
     error ExpiryNotExtended(bytes32 entityKey, BlockNumber newExpiresAt, BlockNumber currentExpiresAt);
-
     /// @dev Reverted when transfer target is the zero address.
     error TransferToZeroAddress(bytes32 entityKey);
-
     /// @dev Reverted when transfer target is the current owner (no-op).
     error TransferToSelf(bytes32 entityKey);
-
     /// @dev Reverted when expire is called on an entity that hasn't expired yet.
     error EntityNotExpired(bytes32 entityKey, BlockNumber expiresAt);
 

--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -2,8 +2,8 @@
 pragma solidity ^0.8.24;
 
 import {BlockNumber} from "./BlockNumber.sol";
+import {Ident32, validateIdent32} from "./Ident32.sol";
 import {Mime128} from "./types/Mime128.sol";
-import {validateIdent32} from "./Ident32.sol";
 
 type OpKey is uint256;
 type TxKey is uint256;
@@ -65,7 +65,7 @@ library EntityHashing {
     /// Attributes must be sorted ascending by name for deterministic hash
     /// computation and name-uniqueness enforcement.
     struct Attribute {
-        bytes32 name;
+        Ident32 name;
         uint8 valueType;
         bytes value;
     }
@@ -103,8 +103,8 @@ library EntityHashing {
     /// @dev Reverted when `execute()` is called with an empty ops array.
     error EmptyBatch();
     error AttributesNotSorted();
-    error InvalidValueLength(bytes32 name, uint8 valueType, uint256 length);
-    error InvalidValueType(bytes32 name, uint8 valueType);
+    error InvalidValueLength(Ident32 name, uint8 valueType, uint256 length);
+    error InvalidValueType(Ident32 name, uint8 valueType);
     /// @dev Reverted when opType is unrecognized (including 0 / uninitialized).
     error InvalidOpType(uint8 opType);
 
@@ -208,10 +208,10 @@ library EntityHashing {
     /// previous (lexicographic on the packed bytes32), enforcing sorted
     /// order and name uniqueness.
     /// @return The updated rolling hash.
-    function attributeHash(bytes32 prevName, bytes32 chain, Attribute calldata attr)
+    function attributeHash(Ident32 prevName, bytes32 chain, Attribute calldata attr)
         internal
         pure
-        returns (bytes32, bytes32)
+        returns (Ident32, bytes32)
     {
         validateIdent32(attr.name);
         if (attr.name <= prevName) revert AttributesNotSorted();
@@ -226,7 +226,8 @@ library EntityHashing {
             revert InvalidValueType(attr.name, vt);
         }
 
-        bytes32 attrHash = keccak256(abi.encode(ATTRIBUTE_TYPEHASH, attr.name, attr.valueType, keccak256(attr.value)));
+        bytes32 attrHash =
+            keccak256(abi.encode(ATTRIBUTE_TYPEHASH, Ident32.unwrap(attr.name), attr.valueType, keccak256(attr.value)));
         return (attr.name, keccak256(abi.encodePacked(chain, attrHash)));
     }
 
@@ -245,7 +246,7 @@ library EntityHashing {
             revert TooManyAttributes(attributes.length, MAX_ATTRIBUTES);
         }
         bytes32 attrChain;
-        bytes32 prevName;
+        Ident32 prevName;
         for (uint256 i = 0; i < attributes.length; i++) {
             (prevName, attrChain) = attributeHash(prevName, attrChain, attributes[i]);
         }

--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import {BlockNumber} from "./BlockNumber.sol";
 import {Mime128} from "./types/Mime128.sol";
+import {validateIdent32} from "./Ident32.sol";
 
 type OpKey is uint256;
 type TxKey is uint256;
@@ -212,6 +213,7 @@ library EntityHashing {
         pure
         returns (bytes32, bytes32)
     {
+        validateIdent32(attr.name);
         if (attr.name <= prevName) revert AttributesNotSorted();
 
         uint8 vt = attr.valueType;

--- a/src/Ident32.sol
+++ b/src/Ident32.sol
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+error Ident32Empty();
+error Ident32TooLong(uint256 length);
+error Ident32InvalidByte(uint256 position, bytes1 value);
+
+/// @dev Bitmap of valid identifier characters: a-z, 0-9, '.', '-', '_'.
+///   bits 45–46  (0x2D–0x2E): set  (hyphen, dot)
+///   bits 48–57  (0x30–0x39): set  (digits)
+///   bit  95     (0x5F):      set  (underscore)
+///   bits 97–122 (0x61–0x7A): set  (lowercase)
+uint256 constant IDENT_CHARSET =
+    (1 << 0x2D) | (1 << 0x2E) | (((1 << 10) - 1) << 0x30) | (1 << 0x5F) | (((1 << 26) - 1) << 0x61);
+
+/// @dev Bitmap for the leading byte: a-z only.
+///   bits 97–122 (0x61–0x7A): set
+uint256 constant IDENT_LEADING = ((1 << 26) - 1) << 0x61;
+
+/// @notice Encode a string into a left-aligned, zero-padded bytes32.
+/// Reverts if empty or longer than 32 bytes.
+function encodeIdent32(string memory value) pure returns (bytes32 result) {
+    bytes memory b = bytes(value);
+    if (b.length == 0) revert Ident32Empty();
+    if (b.length > 32) revert Ident32TooLong(b.length);
+    assembly {
+        result := mload(add(b, 32))
+    }
+}
+
+/// @notice Decode a bytes32 back into a string.
+/// Strips trailing zero bytes to recover the original length.
+function decodeIdent32(bytes32 value) pure returns (string memory) {
+    bytes memory buf = new bytes(32);
+    assembly {
+        mstore(add(buf, 32), value)
+    }
+    uint256 len = 32;
+    while (len > 0 && buf[len - 1] == 0) {
+        len--;
+    }
+    assembly {
+        mstore(buf, len)
+    }
+    return string(buf);
+}
+
+/// @notice Validate that a bytes32 is a valid identifier.
+/// @dev Leading byte must be a-z. Subsequent bytes must be in IDENT_CHARSET
+/// (a-z, 0-9, '.', '-', '_'). Once a zero byte is encountered, all remaining
+/// bytes must also be zero (left-aligned, no embedded nulls).
+/// @return len The number of non-zero bytes (1–32).
+function validateIdent32(bytes32 value) pure returns (uint256 len) {
+    uint8 b0 = uint8(value[0]);
+    if (b0 == 0) revert Ident32Empty();
+    if ((IDENT_LEADING >> b0) & 1 == 0) revert Ident32InvalidByte(0, bytes1(b0));
+    len = 1;
+
+    for (uint256 j = 1; j < 32; j++) {
+        uint8 b = uint8(value[j]);
+        if (b == 0) {
+            // Verify remaining bytes are all zero (no embedded nulls).
+            for (uint256 k = j + 1; k < 32; k++) {
+                if (uint8(value[k]) != 0) {
+                    revert Ident32InvalidByte(k, bytes1(uint8(value[k])));
+                }
+            }
+            return len;
+        }
+        if ((IDENT_CHARSET >> b) & 1 == 0) {
+            revert Ident32InvalidByte(j, bytes1(b));
+        }
+        len++;
+    }
+}

--- a/src/Ident32.sol
+++ b/src/Ident32.sol
@@ -1,6 +1,41 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
+type Ident32 is bytes32;
+
+using {
+    Ident32_eq as ==,
+    Ident32_neq as !=,
+    Ident32_lt as <,
+    Ident32_lte as <=,
+    Ident32_gt as >,
+    Ident32_gte as >=
+} for Ident32 global;
+
+function Ident32_eq(Ident32 a, Ident32 b) pure returns (bool) {
+    return Ident32.unwrap(a) == Ident32.unwrap(b);
+}
+
+function Ident32_neq(Ident32 a, Ident32 b) pure returns (bool) {
+    return Ident32.unwrap(a) != Ident32.unwrap(b);
+}
+
+function Ident32_lt(Ident32 a, Ident32 b) pure returns (bool) {
+    return Ident32.unwrap(a) < Ident32.unwrap(b);
+}
+
+function Ident32_lte(Ident32 a, Ident32 b) pure returns (bool) {
+    return Ident32.unwrap(a) <= Ident32.unwrap(b);
+}
+
+function Ident32_gt(Ident32 a, Ident32 b) pure returns (bool) {
+    return Ident32.unwrap(a) > Ident32.unwrap(b);
+}
+
+function Ident32_gte(Ident32 a, Ident32 b) pure returns (bool) {
+    return Ident32.unwrap(a) >= Ident32.unwrap(b);
+}
+
 error Ident32Empty();
 error Ident32TooLong(uint256 length);
 error Ident32InvalidByte(uint256 position, bytes1 value);
@@ -17,23 +52,26 @@ uint256 constant IDENT_CHARSET =
 ///   bits 97–122 (0x61–0x7A): set
 uint256 constant IDENT_LEADING = ((1 << 26) - 1) << 0x61;
 
-/// @notice Encode a string into a left-aligned, zero-padded bytes32.
+/// @notice Encode a string into a left-aligned, zero-padded Ident32.
 /// Reverts if empty or longer than 32 bytes.
-function encodeIdent32(string memory value) pure returns (bytes32 result) {
+function encodeIdent32(string memory value) pure returns (Ident32) {
     bytes memory b = bytes(value);
     if (b.length == 0) revert Ident32Empty();
     if (b.length > 32) revert Ident32TooLong(b.length);
+    bytes32 result;
     assembly {
         result := mload(add(b, 32))
     }
+    return Ident32.wrap(result);
 }
 
-/// @notice Decode a bytes32 back into a string.
+/// @notice Decode an Ident32 back into a string.
 /// Strips trailing zero bytes to recover the original length.
-function decodeIdent32(bytes32 value) pure returns (string memory) {
+function decodeIdent32(Ident32 value) pure returns (string memory) {
+    bytes32 raw = Ident32.unwrap(value);
     bytes memory buf = new bytes(32);
     assembly {
-        mstore(add(buf, 32), value)
+        mstore(add(buf, 32), raw)
     }
     uint256 len = 32;
     while (len > 0 && buf[len - 1] == 0) {
@@ -45,24 +83,25 @@ function decodeIdent32(bytes32 value) pure returns (string memory) {
     return string(buf);
 }
 
-/// @notice Validate that a bytes32 is a valid identifier.
+/// @notice Validate that an Ident32 is a valid identifier.
 /// @dev Leading byte must be a-z. Subsequent bytes must be in IDENT_CHARSET
 /// (a-z, 0-9, '.', '-', '_'). Once a zero byte is encountered, all remaining
 /// bytes must also be zero (left-aligned, no embedded nulls).
 /// @return len The number of non-zero bytes (1–32).
-function validateIdent32(bytes32 value) pure returns (uint256 len) {
-    uint8 b0 = uint8(value[0]);
+function validateIdent32(Ident32 value) pure returns (uint256 len) {
+    bytes32 raw = Ident32.unwrap(value);
+    uint8 b0 = uint8(raw[0]);
     if (b0 == 0) revert Ident32Empty();
     if ((IDENT_LEADING >> b0) & 1 == 0) revert Ident32InvalidByte(0, bytes1(b0));
     len = 1;
 
     for (uint256 j = 1; j < 32; j++) {
-        uint8 b = uint8(value[j]);
+        uint8 b = uint8(raw[j]);
         if (b == 0) {
             // Verify remaining bytes are all zero (no embedded nulls).
             for (uint256 k = j + 1; k < 32; k++) {
-                if (uint8(value[k]) != 0) {
-                    revert Ident32InvalidByte(k, bytes1(uint8(value[k])));
+                if (uint8(raw[k]) != 0) {
+                    revert Ident32InvalidByte(k, bytes1(uint8(raw[k])));
                 }
             }
             return len;

--- a/test/unit/Ident32.t.sol
+++ b/test/unit/Ident32.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 import {
+    Ident32,
     Ident32Empty,
     Ident32TooLong,
     Ident32InvalidByte,
@@ -18,11 +19,11 @@ contract Ident32Test is Test {
     // Calldata wrapper
     // -------------------------------------------------------------------------
 
-    function doValidate(bytes32 value) external pure returns (uint256) {
+    function doValidate(Ident32 value) external pure returns (uint256) {
         return validateIdent32(value);
     }
 
-    function doEncode(string calldata value) external pure returns (bytes32) {
+    function doEncode(string calldata value) external pure returns (Ident32) {
         return encodeIdent32(value);
     }
 
@@ -104,7 +105,7 @@ contract Ident32Test is Test {
     }
 
     function test_validate_maxLength32() public view {
-        bytes32 v = encodeIdent32("abcdefghijklmnopqrstuvwxyz012345");
+        Ident32 v = encodeIdent32("abcdefghijklmnopqrstuvwxyz012345");
         assertEq(this.doValidate(v), 32);
     }
 
@@ -113,25 +114,25 @@ contract Ident32Test is Test {
     // =========================================================================
 
     function test_validate_rejectsLeadingDigit() public {
-        bytes32 v = encodeIdent32("0count");
+        Ident32 v = encodeIdent32("0count");
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1("0")));
         this.doValidate(v);
     }
 
     function test_validate_rejectsLeadingDot() public {
-        bytes32 v = encodeIdent32(".hidden");
+        Ident32 v = encodeIdent32(".hidden");
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1(".")));
         this.doValidate(v);
     }
 
     function test_validate_rejectsLeadingHyphen() public {
-        bytes32 v = encodeIdent32("-flag");
+        Ident32 v = encodeIdent32("-flag");
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1("-")));
         this.doValidate(v);
     }
 
     function test_validate_rejectsLeadingUnderscore() public {
-        bytes32 v = encodeIdent32("_private");
+        Ident32 v = encodeIdent32("_private");
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1("_")));
         this.doValidate(v);
     }
@@ -149,105 +150,98 @@ contract Ident32Test is Test {
     // =========================================================================
 
     function test_validate_rejectsUppercase_A() public {
-        bytes32 v;
-        v = bytes32(bytes1("A"));
+        Ident32 v = Ident32.wrap(bytes32(bytes1("A")));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1("A")));
         this.doValidate(v);
     }
 
     function test_validate_rejectsUppercase_Z() public {
-        bytes32 v;
-        v = bytes32(bytes1("Z"));
+        Ident32 v = Ident32.wrap(bytes32(bytes1("Z")));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1("Z")));
         this.doValidate(v);
     }
 
     function test_validate_rejectsUppercaseInMiddle() public {
-        bytes32 v = encodeIdent32("abcde");
-        // Manually set byte 2 to 'X'
-        v = v | (bytes32(bytes1("X")) >> (2 * 8));
-        // Clear the original 'c' at position 2
-        v = v & ~(bytes32(bytes1(0xFF)) >> (2 * 8));
-        v = v | (bytes32(bytes1("X")) >> (2 * 8));
+        bytes32 raw = Ident32.unwrap(encodeIdent32("abcde"));
+        // Clear the original 'c' at position 2 and set to 'X'
+        raw = raw & ~(bytes32(bytes1(0xFF)) >> (2 * 8));
+        raw = raw | (bytes32(bytes1("X")) >> (2 * 8));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("X")));
-        this.doValidate(v);
+        this.doValidate(Ident32.wrap(raw));
     }
 
     function test_validate_rejectsSpace() public {
-        bytes32 v = encodeIdent32("ab");
-        v = v | (bytes32(bytes1(" ")) >> (2 * 8));
+        bytes32 raw = Ident32.unwrap(encodeIdent32("ab"));
+        raw = raw | (bytes32(bytes1(" ")) >> (2 * 8));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1(" ")));
-        this.doValidate(v);
+        this.doValidate(Ident32.wrap(raw));
     }
 
     function test_validate_rejectsControlChar() public {
-        bytes32 v;
-        v = bytes32(bytes1(0x09)); // tab
+        Ident32 v = Ident32.wrap(bytes32(bytes1(0x09))); // tab
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1(0x09)));
         this.doValidate(v);
     }
 
     function test_validate_rejectsDel() public {
-        bytes32 v;
-        v = bytes32(bytes1(0x7F));
+        Ident32 v = Ident32.wrap(bytes32(bytes1(0x7F)));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1(0x7F)));
         this.doValidate(v);
     }
 
     function test_validate_rejectsHighByte() public {
-        bytes32 v;
-        v = bytes32(bytes1(0x80));
+        Ident32 v = Ident32.wrap(bytes32(bytes1(0x80)));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1(0x80)));
         this.doValidate(v);
     }
 
     function test_validate_rejectsSlash() public {
-        bytes32 v = encodeIdent32("ab");
-        v = v | (bytes32(bytes1("/")) >> (2 * 8));
+        bytes32 raw = Ident32.unwrap(encodeIdent32("ab"));
+        raw = raw | (bytes32(bytes1("/")) >> (2 * 8));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("/")));
-        this.doValidate(v);
+        this.doValidate(Ident32.wrap(raw));
     }
 
     function test_validate_rejectsColon() public {
-        bytes32 v = encodeIdent32("ab");
-        v = v | (bytes32(bytes1(":")) >> (2 * 8));
+        bytes32 raw = Ident32.unwrap(encodeIdent32("ab"));
+        raw = raw | (bytes32(bytes1(":")) >> (2 * 8));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1(":")));
-        this.doValidate(v);
+        this.doValidate(Ident32.wrap(raw));
     }
 
     function test_validate_rejectsSemicolon() public {
-        bytes32 v = encodeIdent32("ab");
-        v = v | (bytes32(bytes1(";")) >> (2 * 8));
+        bytes32 raw = Ident32.unwrap(encodeIdent32("ab"));
+        raw = raw | (bytes32(bytes1(";")) >> (2 * 8));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1(";")));
-        this.doValidate(v);
+        this.doValidate(Ident32.wrap(raw));
     }
 
     function test_validate_rejectsEquals() public {
-        bytes32 v = encodeIdent32("ab");
-        v = v | (bytes32(bytes1("=")) >> (2 * 8));
+        bytes32 raw = Ident32.unwrap(encodeIdent32("ab"));
+        raw = raw | (bytes32(bytes1("=")) >> (2 * 8));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("=")));
-        this.doValidate(v);
+        this.doValidate(Ident32.wrap(raw));
     }
 
     function test_validate_rejectsAt() public {
-        bytes32 v = encodeIdent32("ab");
-        v = v | (bytes32(bytes1("@")) >> (2 * 8));
+        bytes32 raw = Ident32.unwrap(encodeIdent32("ab"));
+        raw = raw | (bytes32(bytes1("@")) >> (2 * 8));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("@")));
-        this.doValidate(v);
+        this.doValidate(Ident32.wrap(raw));
     }
 
     function test_validate_rejectsExclamation() public {
-        bytes32 v = encodeIdent32("ab");
-        v = v | (bytes32(bytes1("!")) >> (2 * 8));
+        bytes32 raw = Ident32.unwrap(encodeIdent32("ab"));
+        raw = raw | (bytes32(bytes1("!")) >> (2 * 8));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("!")));
-        this.doValidate(v);
+        this.doValidate(Ident32.wrap(raw));
     }
 
     function test_validate_rejectsHash() public {
-        bytes32 v = encodeIdent32("ab");
-        v = v | (bytes32(bytes1("#")) >> (2 * 8));
+        bytes32 raw = Ident32.unwrap(encodeIdent32("ab"));
+        raw = raw | (bytes32(bytes1("#")) >> (2 * 8));
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("#")));
-        this.doValidate(v);
+        this.doValidate(Ident32.wrap(raw));
     }
 
     // =========================================================================
@@ -256,12 +250,12 @@ contract Ident32Test is Test {
 
     function test_validate_rejectsEmpty() public {
         vm.expectRevert(Ident32Empty.selector);
-        this.doValidate(bytes32(0));
+        this.doValidate(Ident32.wrap(bytes32(0)));
     }
 
     function test_validate_rejectsEmbeddedNull() public {
         // "ab\0cd" — null at position 2, then non-zero at 3
-        bytes32 v = bytes32(bytes4(0x61620063)); // a b \0 c
+        Ident32 v = Ident32.wrap(bytes32(bytes4(0x61620063))); // a b \0 c
         vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(3), bytes1("c")));
         this.doValidate(v);
     }

--- a/test/unit/Ident32.t.sol
+++ b/test/unit/Ident32.t.sol
@@ -1,0 +1,323 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {
+    Ident32Empty,
+    Ident32TooLong,
+    Ident32InvalidByte,
+    IDENT_CHARSET,
+    IDENT_LEADING,
+    encodeIdent32,
+    decodeIdent32,
+    validateIdent32
+} from "../../src/Ident32.sol";
+
+contract Ident32Test is Test {
+    // -------------------------------------------------------------------------
+    // Calldata wrapper
+    // -------------------------------------------------------------------------
+
+    function doValidate(bytes32 value) external pure returns (uint256) {
+        return validateIdent32(value);
+    }
+
+    function doEncode(string calldata value) external pure returns (bytes32) {
+        return encodeIdent32(value);
+    }
+
+    // =========================================================================
+    // encodeIdent32 / decodeIdent32 — roundtrip
+    // =========================================================================
+
+    function test_encodeDecode_short() public pure {
+        assertEq(decodeIdent32(encodeIdent32("count")), "count");
+    }
+
+    function test_encodeDecode_single() public pure {
+        assertEq(decodeIdent32(encodeIdent32("x")), "x");
+    }
+
+    function test_encodeDecode_dotted() public pure {
+        assertEq(decodeIdent32(encodeIdent32("content.length")), "content.length");
+    }
+
+    function test_encodeDecode_kebab() public pure {
+        assertEq(decodeIdent32(encodeIdent32("x-custom")), "x-custom");
+    }
+
+    function test_encodeDecode_snake() public pure {
+        assertEq(decodeIdent32(encodeIdent32("file_size")), "file_size");
+    }
+
+    function test_encodeDecode_digits() public pure {
+        assertEq(decodeIdent32(encodeIdent32("v2")), "v2");
+    }
+
+    function test_encodeDecode_maxLength() public pure {
+        // 32 chars: a + 31 lowercase chars
+        string memory v = "abcdefghijklmnopqrstuvwxyz012345";
+        assertEq(bytes(v).length, 32);
+        assertEq(decodeIdent32(encodeIdent32(v)), v);
+    }
+
+    function test_encode_revertsEmpty() public {
+        vm.expectRevert(Ident32Empty.selector);
+        this.doEncode("");
+    }
+
+    function test_encode_revertsTooLong() public {
+        vm.expectRevert(abi.encodeWithSelector(Ident32TooLong.selector, uint256(33)));
+        this.doEncode("abcdefghijklmnopqrstuvwxyz0123456");
+    }
+
+    // =========================================================================
+    // validateIdent32 — valid identifiers
+    // =========================================================================
+
+    function test_validate_simple() public view {
+        assertEq(this.doValidate(encodeIdent32("count")), 5);
+    }
+
+    function test_validate_singleChar() public view {
+        assertEq(this.doValidate(encodeIdent32("x")), 1);
+    }
+
+    function test_validate_withDigits() public view {
+        assertEq(this.doValidate(encodeIdent32("tag2")), 4);
+    }
+
+    function test_validate_dotted() public view {
+        assertEq(this.doValidate(encodeIdent32("content.length")), 14);
+    }
+
+    function test_validate_kebab() public view {
+        assertEq(this.doValidate(encodeIdent32("x-custom")), 8);
+    }
+
+    function test_validate_snake() public view {
+        assertEq(this.doValidate(encodeIdent32("file_size")), 9);
+    }
+
+    function test_validate_allSeparators() public view {
+        assertEq(this.doValidate(encodeIdent32("a.b-c_d")), 7);
+    }
+
+    function test_validate_maxLength32() public view {
+        bytes32 v = encodeIdent32("abcdefghijklmnopqrstuvwxyz012345");
+        assertEq(this.doValidate(v), 32);
+    }
+
+    // =========================================================================
+    // validateIdent32 — leading byte
+    // =========================================================================
+
+    function test_validate_rejectsLeadingDigit() public {
+        bytes32 v = encodeIdent32("0count");
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1("0")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsLeadingDot() public {
+        bytes32 v = encodeIdent32(".hidden");
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1(".")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsLeadingHyphen() public {
+        bytes32 v = encodeIdent32("-flag");
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1("-")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsLeadingUnderscore() public {
+        bytes32 v = encodeIdent32("_private");
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1("_")));
+        this.doValidate(v);
+    }
+
+    function test_validate_acceptsLeading_a() public view {
+        assertEq(this.doValidate(encodeIdent32("a")), 1);
+    }
+
+    function test_validate_acceptsLeading_z() public view {
+        assertEq(this.doValidate(encodeIdent32("z")), 1);
+    }
+
+    // =========================================================================
+    // validateIdent32 — charset rejections
+    // =========================================================================
+
+    function test_validate_rejectsUppercase_A() public {
+        bytes32 v;
+        v = bytes32(bytes1("A"));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1("A")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsUppercase_Z() public {
+        bytes32 v;
+        v = bytes32(bytes1("Z"));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1("Z")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsUppercaseInMiddle() public {
+        bytes32 v = encodeIdent32("abcde");
+        // Manually set byte 2 to 'X'
+        v = v | (bytes32(bytes1("X")) >> (2 * 8));
+        // Clear the original 'c' at position 2
+        v = v & ~(bytes32(bytes1(0xFF)) >> (2 * 8));
+        v = v | (bytes32(bytes1("X")) >> (2 * 8));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("X")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsSpace() public {
+        bytes32 v = encodeIdent32("ab");
+        v = v | (bytes32(bytes1(" ")) >> (2 * 8));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1(" ")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsControlChar() public {
+        bytes32 v;
+        v = bytes32(bytes1(0x09)); // tab
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1(0x09)));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsDel() public {
+        bytes32 v;
+        v = bytes32(bytes1(0x7F));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1(0x7F)));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsHighByte() public {
+        bytes32 v;
+        v = bytes32(bytes1(0x80));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(0), bytes1(0x80)));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsSlash() public {
+        bytes32 v = encodeIdent32("ab");
+        v = v | (bytes32(bytes1("/")) >> (2 * 8));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("/")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsColon() public {
+        bytes32 v = encodeIdent32("ab");
+        v = v | (bytes32(bytes1(":")) >> (2 * 8));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1(":")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsSemicolon() public {
+        bytes32 v = encodeIdent32("ab");
+        v = v | (bytes32(bytes1(";")) >> (2 * 8));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1(";")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsEquals() public {
+        bytes32 v = encodeIdent32("ab");
+        v = v | (bytes32(bytes1("=")) >> (2 * 8));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("=")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsAt() public {
+        bytes32 v = encodeIdent32("ab");
+        v = v | (bytes32(bytes1("@")) >> (2 * 8));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("@")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsExclamation() public {
+        bytes32 v = encodeIdent32("ab");
+        v = v | (bytes32(bytes1("!")) >> (2 * 8));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("!")));
+        this.doValidate(v);
+    }
+
+    function test_validate_rejectsHash() public {
+        bytes32 v = encodeIdent32("ab");
+        v = v | (bytes32(bytes1("#")) >> (2 * 8));
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(2), bytes1("#")));
+        this.doValidate(v);
+    }
+
+    // =========================================================================
+    // validateIdent32 — empty and embedded nulls
+    // =========================================================================
+
+    function test_validate_rejectsEmpty() public {
+        vm.expectRevert(Ident32Empty.selector);
+        this.doValidate(bytes32(0));
+    }
+
+    function test_validate_rejectsEmbeddedNull() public {
+        // "ab\0cd" — null at position 2, then non-zero at 3
+        bytes32 v = bytes32(bytes4(0x61620063)); // a b \0 c
+        vm.expectRevert(abi.encodeWithSelector(Ident32InvalidByte.selector, uint256(3), bytes1("c")));
+        this.doValidate(v);
+    }
+
+    // =========================================================================
+    // IDENT_CHARSET bitmap — spot checks
+    // =========================================================================
+
+    function test_bitmap_lowercaseSet() public pure {
+        for (uint8 c = 0x61; c <= 0x7A; c++) {
+            assertTrue((IDENT_CHARSET >> c) & 1 == 1);
+        }
+    }
+
+    function test_bitmap_digitsSet() public pure {
+        for (uint8 c = 0x30; c <= 0x39; c++) {
+            assertTrue((IDENT_CHARSET >> c) & 1 == 1);
+        }
+    }
+
+    function test_bitmap_separatorsSet() public pure {
+        assertTrue((IDENT_CHARSET >> 0x2D) & 1 == 1); // -
+        assertTrue((IDENT_CHARSET >> 0x2E) & 1 == 1); // .
+        assertTrue((IDENT_CHARSET >> 0x5F) & 1 == 1); // _
+    }
+
+    function test_bitmap_uppercaseUnset() public pure {
+        for (uint8 c = 0x41; c <= 0x5A; c++) {
+            assertTrue((IDENT_CHARSET >> c) & 1 == 0);
+        }
+    }
+
+    function test_bitmap_spaceUnset() public pure {
+        assertTrue((IDENT_CHARSET >> 0x20) & 1 == 0);
+    }
+
+    function test_bitmap_slashUnset() public pure {
+        assertTrue((IDENT_CHARSET >> 0x2F) & 1 == 0);
+    }
+
+    function test_bitmap_colonUnset() public pure {
+        assertTrue((IDENT_CHARSET >> 0x3A) & 1 == 0);
+    }
+
+    function test_bitmap_leadingOnlyLowercase() public pure {
+        // a-z set
+        for (uint8 c = 0x61; c <= 0x7A; c++) {
+            assertTrue((IDENT_LEADING >> c) & 1 == 1);
+        }
+        // digits unset
+        for (uint8 c = 0x30; c <= 0x39; c++) {
+            assertTrue((IDENT_LEADING >> c) & 1 == 0);
+        }
+        // separators unset
+        assertTrue((IDENT_LEADING >> 0x2D) & 1 == 0);
+        assertTrue((IDENT_LEADING >> 0x2E) & 1 == 0);
+        assertTrue((IDENT_LEADING >> 0x5F) & 1 == 0);
+    }
+}

--- a/test/unit/hashing/AttributeHash.t.sol
+++ b/test/unit/hashing/AttributeHash.t.sol
@@ -5,6 +5,7 @@ import {Test} from "forge-std/Test.sol";
 import {Lib} from "../../utils/Lib.sol";
 import {EntityHashing} from "../../../src/EntityHashing.sol";
 import {EntityRegistry} from "../../../src/EntityRegistry.sol";
+import {IDENT_CHARSET, IDENT_LEADING} from "../../../src/Ident32.sol";
 
 contract AttributeHashTest is Test, EntityRegistry {
     function doAttributeHash(bytes32 prevName, bytes32 chain, EntityHashing.Attribute calldata attr)
@@ -215,8 +216,25 @@ contract AttributeHashTest is Test, EntityRegistry {
         return keccak256(abi.encodePacked(prev, h));
     }
 
+    /// @dev Check that a bytes32 is a valid Ident32 (a-z leading, then a-z0-9._- , left-aligned).
+    function _isValidIdent(bytes32 name) internal pure returns (bool) {
+        uint8 b0 = uint8(name[0]);
+        if ((IDENT_LEADING >> b0) & 1 == 0) return false;
+        bool ended;
+        for (uint256 i = 1; i < 32; i++) {
+            uint8 b = uint8(name[i]);
+            if (b == 0) {
+                ended = true;
+                continue;
+            }
+            if (ended) return false;
+            if ((IDENT_CHARSET >> b) & 1 == 0) return false;
+        }
+        return true;
+    }
+
     function test_attributeHash_fuzz_uint(bytes32 name, uint256 value) public {
-        vm.assume(name != bytes32(0));
+        vm.assume(_isValidIdent(name));
         EntityHashing.Attribute memory attr =
             EntityHashing.Attribute({name: name, valueType: EntityHashing.ATTR_UINT, value: abi.encode(value)});
         (, bytes32 chain) = this.doAttributeHash(bytes32(0), bytes32(0), attr);
@@ -224,7 +242,7 @@ contract AttributeHashTest is Test, EntityRegistry {
     }
 
     function test_attributeHash_fuzz_entityKey(bytes32 name, bytes32 value) public {
-        vm.assume(name != bytes32(0));
+        vm.assume(_isValidIdent(name));
         EntityHashing.Attribute memory attr =
             EntityHashing.Attribute({name: name, valueType: EntityHashing.ATTR_ENTITY_KEY, value: abi.encode(value)});
         (, bytes32 chain) = this.doAttributeHash(bytes32(0), bytes32(0), attr);
@@ -232,7 +250,7 @@ contract AttributeHashTest is Test, EntityRegistry {
     }
 
     function test_attributeHash_fuzz_string(bytes32 name, bytes calldata value) public {
-        vm.assume(name != bytes32(0));
+        vm.assume(_isValidIdent(name));
         vm.assume(value.length <= 1024);
         EntityHashing.Attribute memory attr =
             EntityHashing.Attribute({name: name, valueType: EntityHashing.ATTR_STRING, value: value});

--- a/test/unit/hashing/AttributeHash.t.sol
+++ b/test/unit/hashing/AttributeHash.t.sol
@@ -5,25 +5,25 @@ import {Test} from "forge-std/Test.sol";
 import {Lib} from "../../utils/Lib.sol";
 import {EntityHashing} from "../../../src/EntityHashing.sol";
 import {EntityRegistry} from "../../../src/EntityRegistry.sol";
-import {IDENT_CHARSET, IDENT_LEADING} from "../../../src/Ident32.sol";
+import {Ident32, IDENT_CHARSET, IDENT_LEADING} from "../../../src/Ident32.sol";
 
 contract AttributeHashTest is Test, EntityRegistry {
-    function doAttributeHash(bytes32 prevName, bytes32 chain, EntityHashing.Attribute calldata attr)
+    function doAttributeHash(Ident32 prevName, bytes32 chain, EntityHashing.Attribute calldata attr)
         external
         pure
-        returns (bytes32, bytes32)
+        returns (Ident32, bytes32)
     {
         return EntityHashing.attributeHash(prevName, chain, attr);
     }
 
     function _hashOne(EntityHashing.Attribute memory attr) internal view returns (bytes32) {
-        (, bytes32 chain) = this.doAttributeHash(bytes32(0), bytes32(0), attr);
+        (, bytes32 chain) = this.doAttributeHash(Ident32.wrap(bytes32(0)), bytes32(0), attr);
         return chain;
     }
 
     function _hashMany(EntityHashing.Attribute[] memory attrs) internal view returns (bytes32) {
         bytes32 chain;
-        bytes32 prevName;
+        Ident32 prevName;
         for (uint256 i = 0; i < attrs.length; i++) {
             (prevName, chain) = this.doAttributeHash(prevName, chain, attrs[i]);
         }
@@ -77,7 +77,12 @@ contract AttributeHashTest is Test, EntityRegistry {
             abi.encodePacked(
                 bytes32(0),
                 keccak256(
-                    abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, attr.name, attr.valueType, keccak256(attr.value))
+                    abi.encode(
+                        EntityHashing.ATTRIBUTE_TYPEHASH,
+                        Ident32.unwrap(attr.name),
+                        attr.valueType,
+                        keccak256(attr.value)
+                    )
                 )
             )
         );
@@ -90,7 +95,12 @@ contract AttributeHashTest is Test, EntityRegistry {
             abi.encodePacked(
                 bytes32(0),
                 keccak256(
-                    abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, attr.name, attr.valueType, keccak256(attr.value))
+                    abi.encode(
+                        EntityHashing.ATTRIBUTE_TYPEHASH,
+                        Ident32.unwrap(attr.name),
+                        attr.valueType,
+                        keccak256(attr.value)
+                    )
                 )
             )
         );
@@ -104,7 +114,12 @@ contract AttributeHashTest is Test, EntityRegistry {
             abi.encodePacked(
                 bytes32(0),
                 keccak256(
-                    abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, attr.name, attr.valueType, keccak256(attr.value))
+                    abi.encode(
+                        EntityHashing.ATTRIBUTE_TYPEHASH,
+                        Ident32.unwrap(attr.name),
+                        attr.valueType,
+                        keccak256(attr.value)
+                    )
                 )
             )
         );
@@ -122,8 +137,12 @@ contract AttributeHashTest is Test, EntityRegistry {
         EntityHashing.Attribute memory a = Lib.uintAttr("count", 42);
         EntityHashing.Attribute memory b = Lib.stringAttr("label", "hello");
 
-        bytes32 hashA = keccak256(abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, a.name, a.valueType, keccak256(a.value)));
-        bytes32 hashB = keccak256(abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, b.name, b.valueType, keccak256(b.value)));
+        bytes32 hashA = keccak256(
+            abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, Ident32.unwrap(a.name), a.valueType, keccak256(a.value))
+        );
+        bytes32 hashB = keccak256(
+            abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, Ident32.unwrap(b.name), b.valueType, keccak256(b.value))
+        );
         bytes32 chain = keccak256(abi.encodePacked(bytes32(0), hashA));
         chain = keccak256(abi.encodePacked(chain, hashB));
 
@@ -209,7 +228,11 @@ contract AttributeHashTest is Test, EntityRegistry {
     // ---- Fuzz ----
 
     function _refHash(EntityHashing.Attribute memory attr) internal pure returns (bytes32) {
-        return keccak256(abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, attr.name, attr.valueType, keccak256(attr.value)));
+        return keccak256(
+            abi.encode(
+                EntityHashing.ATTRIBUTE_TYPEHASH, Ident32.unwrap(attr.name), attr.valueType, keccak256(attr.value)
+            )
+        );
     }
 
     function _refChain(bytes32 prev, bytes32 h) internal pure returns (bytes32) {
@@ -235,17 +258,19 @@ contract AttributeHashTest is Test, EntityRegistry {
 
     function test_attributeHash_fuzz_uint(bytes32 name, uint256 value) public {
         vm.assume(_isValidIdent(name));
-        EntityHashing.Attribute memory attr =
-            EntityHashing.Attribute({name: name, valueType: EntityHashing.ATTR_UINT, value: abi.encode(value)});
-        (, bytes32 chain) = this.doAttributeHash(bytes32(0), bytes32(0), attr);
+        EntityHashing.Attribute memory attr = EntityHashing.Attribute({
+            name: Ident32.wrap(name), valueType: EntityHashing.ATTR_UINT, value: abi.encode(value)
+        });
+        (, bytes32 chain) = this.doAttributeHash(Ident32.wrap(bytes32(0)), bytes32(0), attr);
         assertEq(chain, _refChain(bytes32(0), _refHash(attr)));
     }
 
     function test_attributeHash_fuzz_entityKey(bytes32 name, bytes32 value) public {
         vm.assume(_isValidIdent(name));
-        EntityHashing.Attribute memory attr =
-            EntityHashing.Attribute({name: name, valueType: EntityHashing.ATTR_ENTITY_KEY, value: abi.encode(value)});
-        (, bytes32 chain) = this.doAttributeHash(bytes32(0), bytes32(0), attr);
+        EntityHashing.Attribute memory attr = EntityHashing.Attribute({
+            name: Ident32.wrap(name), valueType: EntityHashing.ATTR_ENTITY_KEY, value: abi.encode(value)
+        });
+        (, bytes32 chain) = this.doAttributeHash(Ident32.wrap(bytes32(0)), bytes32(0), attr);
         assertEq(chain, _refChain(bytes32(0), _refHash(attr)));
     }
 
@@ -253,8 +278,8 @@ contract AttributeHashTest is Test, EntityRegistry {
         vm.assume(_isValidIdent(name));
         vm.assume(value.length <= 1024);
         EntityHashing.Attribute memory attr =
-            EntityHashing.Attribute({name: name, valueType: EntityHashing.ATTR_STRING, value: value});
-        (, bytes32 chain) = this.doAttributeHash(bytes32(0), bytes32(0), attr);
+            EntityHashing.Attribute({name: Ident32.wrap(name), valueType: EntityHashing.ATTR_STRING, value: value});
+        (, bytes32 chain) = this.doAttributeHash(Ident32.wrap(bytes32(0)), bytes32(0), attr);
         assertEq(chain, _refChain(bytes32(0), _refHash(attr)));
     }
 }

--- a/test/utils/EntityRegistryHarness.sol
+++ b/test/utils/EntityRegistryHarness.sol
@@ -4,15 +4,16 @@ pragma solidity ^0.8.24;
 import {BlockNumber} from "../../src/BlockNumber.sol";
 import {EntityRegistry} from "../../src/EntityRegistry.sol";
 import {EntityHashing} from "../../src/EntityHashing.sol";
+import {Ident32} from "../../src/Ident32.sol";
 import {Mime128} from "../../src/types/Mime128.sol";
 
 /// @dev Harness for pure hash function tests (attributeHash, coreHash, entityStructHash).
 /// No overrides — this is the real contract with exposed internals.
 contract EntityRegistryHarness is EntityRegistry {
-    function exposed_attributeHash(bytes32 prevName, bytes32 chain, EntityHashing.Attribute calldata attr)
+    function exposed_attributeHash(Ident32 prevName, bytes32 chain, EntityHashing.Attribute calldata attr)
         external
         pure
-        returns (bytes32, bytes32)
+        returns (Ident32, bytes32)
     {
         return EntityHashing.attributeHash(prevName, chain, attr);
     }

--- a/test/utils/Lib.sol
+++ b/test/utils/Lib.sol
@@ -4,15 +4,12 @@ pragma solidity ^0.8.24;
 import {BlockNumber} from "../../src/BlockNumber.sol";
 import {EntityHashing} from "../../src/EntityHashing.sol";
 import {Mime128} from "../../src/types/Mime128.sol";
+import {encodeIdent32} from "../../src/Ident32.sol";
 
 library Lib {
-    /// @dev Pack a string into a left-aligned, zero-padded bytes32.
-    function packName(string memory name) internal pure returns (bytes32 result) {
-        bytes memory b = bytes(name);
-        require(b.length <= 32, "name too long");
-        assembly {
-            result := mload(add(b, 32))
-        }
+    /// @dev Pack a string into a validated, left-aligned, zero-padded bytes32.
+    function packName(string memory name) internal pure returns (bytes32) {
+        return encodeIdent32(name);
     }
 
     function createOp(

--- a/test/utils/Lib.sol
+++ b/test/utils/Lib.sol
@@ -3,12 +3,12 @@ pragma solidity ^0.8.24;
 
 import {BlockNumber} from "../../src/BlockNumber.sol";
 import {EntityHashing} from "../../src/EntityHashing.sol";
+import {Ident32, encodeIdent32} from "../../src/Ident32.sol";
 import {Mime128} from "../../src/types/Mime128.sol";
-import {encodeIdent32} from "../../src/Ident32.sol";
 
 library Lib {
-    /// @dev Pack a string into a validated, left-aligned, zero-padded bytes32.
-    function packName(string memory name) internal pure returns (bytes32) {
+    /// @dev Pack a string into a validated, left-aligned, zero-padded Ident32.
+    function packName(string memory name) internal pure returns (Ident32) {
         return encodeIdent32(name);
     }
 


### PR DESCRIPTION
- Introduces `type Ident32 is bytes32` — a user-defined value type with comparison operators and bitmap-validated charset (`a-z 0-9 . - _`, leading byte must be `a-z`)
- Changes `Attribute.name` from bare `bytes32` to `Ident32`, giving compile-time type safety for identifier fields
- Wires `validateIdent32` into `EntityHashing.attributeHash()` before the sort check
- Design document covers charset analysis (3 options evaluated), OpenZeppelin ShortString comparison, and leading-byte rationale

## Files

| File | Change |
|---|---|
| `src/Ident32.sol` | New — `type Ident32 is bytes32`, comparison operators, `IDENT_CHARSET` / `IDENT_LEADING` bitmaps, `validateIdent32`, `encodeIdent32`, `decodeIdent32` |
| `src/EntityHashing.sol` | `Attribute.name`: `bytes32` → `Ident32`. Error signatures updated. `attributeHash` signature uses `Ident32` for `prevName` and return. EIP-712 encoding unwraps via `Ident32.unwrap()` |
| `docs/ident32-encoding.md` | Design doc: charset analysis, OZ ShortString comparison, validation rules, gas cost, integration point |
| `test/unit/Ident32.t.sol` | 47 tests: roundtrip, leading byte, charset rejections, embedded nulls, bitmap checks |
| `test/unit/hashing/AttributeHash.t.sol` | Updated for `Ident32` type — `doAttributeHash` signature, manual EIP-712 encoding uses `Ident32.unwrap()`, fuzz tests constrained via `_isValidIdent` |
| `test/utils/EntityRegistryHarness.sol` | `exposed_attributeHash` signature updated to `Ident32` |
| `test/utils/Lib.sol` | `packName` returns `Ident32`, delegates to `encodeIdent32` |