### PR TITLE
Fixed-size attribute values (bytes → bytes32[4])

### DIFF
--- a/docs/value128-encoding.md
+++ b/docs/value128-encoding.md
@@ -1,0 +1,213 @@
+# Value128: Fixed-Size Attribute Value Encoding
+
+| Property | Value |
+|----------|-------|
+| **Status** | Ideation |
+| **Depends on** | [ADR-API-004](ADR-API-004.md) (String Field Encoding), `src/Ident32.sol`, `src/Mime128.sol` |
+| **Created** | April 2026 |
+
+## Problem
+
+The `Attribute` struct currently uses `bytes value` — a dynamic byte array with no fixed size:
+
+```solidity
+struct Attribute {
+    Ident32 name;
+    uint8 valueType;
+    bytes value;      // ← dynamic, variable length
+}
+```
+
+Three value types are supported:
+- `ATTR_UINT` (0): 32 bytes (abi-encoded uint256)
+- `ATTR_STRING` (1): up to 1024 bytes
+- `ATTR_ENTITY_KEY` (2): 32 bytes (abi-encoded bytes32)
+
+Per ADR-API-004, string attribute values should be capped at **128 bytes** (not 1024), and the protocol treats them as **opaque byte arrays** with byte-level ordering for predicates and sorting.
+
+Replacing `bytes value` with `bytes32[4]` (128 bytes, fixed) would:
+1. Unify all three value types into a single fixed-size representation
+2. Eliminate dynamic ABI encoding overhead (length prefix, padding, pointer indirection)
+3. Make the `Attribute` struct fully fixed-size — simpler calldata layout, predictable gas
+4. Align with the `Mime128` / `Ident32` pattern of fixed-size validated types
+
+The challenge is that `bytes32[4]` must encode three semantically different value types, each with different encoding rules.
+
+## The three encodings
+
+### 1. ATTR_UINT — numeric values
+
+**In `bytes32[4]`:** The uint256 occupies `data[0]` as a right-aligned `bytes32`. Slots `data[1..3]` are zero.
+
+```
+data[0]: 0x000000000000000000000000000000000000000000000000000000000000002a  (42)
+data[1]: 0x0000000000000000000000000000000000000000000000000000000000000000
+data[2]: 0x0000000000000000000000000000000000000000000000000000000000000000
+data[3]: 0x0000000000000000000000000000000000000000000000000000000000000000
+```
+
+**Encoding rule:** `data[0] = bytes32(value)`. Standard ABI uint256 layout — right-aligned, big-endian.
+
+**Sorting:** Byte-level comparison on `data[0]` matches numeric ordering because big-endian uint256 preserves magnitude order under lexicographic comparison.
+
+### 2. ATTR_STRING — opaque byte arrays (NFC UTF-8 by convention)
+
+**In `bytes32[4]`:** Left-aligned, zero-padded — identical to `Mime128` and `Ident32` packing.
+
+```
+"hello world" (11 bytes):
+data[0]: 0x68656c6c6f20776f726c640000000000000000000000000000000000000000
+data[1..3]: 0x00...
+```
+
+**Encoding rule:** Left-aligned, zero-padded. Same as `encodeMime128` byte packing.
+
+**Sorting:** Byte-level comparison across all 4 words matches lexicographic string ordering. Shorter strings sort before longer strings that share the same prefix (`"abc" < "abcd"`).
+
+### 3. ATTR_ENTITY_KEY — cross-references
+
+**In `bytes32[4]`:** `data[0]` holds the entity key. Slots `data[1..3]` are zero. Identical layout to ATTR_UINT.
+
+**Encoding rule:** `data[0] = entityKey`.
+
+## Encoding summary
+
+| Type | `data[0]` | `data[1..3]` | Alignment | Sort semantics |
+|---|---|---|---|---|
+| `ATTR_UINT` | `bytes32(uint256)` | zero | Right-aligned | Numeric (big-endian) |
+| `ATTR_STRING` | First 32 bytes of string | Continuation + zero padding | Left-aligned | Lexicographic (byte-level) |
+| `ATTR_ENTITY_KEY` | Entity key hash | zero | N/A (full word) | Byte-level |
+
+The `valueType` discriminator remains necessary — it distinguishes right-aligned (uint/key) from left-aligned (string) encoding, and prevents cross-type collisions in hash computation.
+
+## Validation
+
+On-chain validation of the value blob is **not necessary**. The `bytes32[4]` is opaque — encoding correctness is the caller's responsibility and is enforced by SDKs. The contract's role is:
+
+1. Hash the value deterministically (always `keccak256(abi.encode(v[0], v[1], v[2], v[3]))`)
+2. Include `valueType` in the hash to prevent cross-type collisions
+3. Accept whatever bytes the caller provides
+
+This matches ADR-API-004's position that string values are opaque byte arrays with no protocol-level encoding validation. The same principle extends to uint and entity key values — a malformed uint that uses all 4 words "wrong" still hashes deterministically. Off-chain indexers interpret the bytes according to `valueType`; the contract just commits to them.
+
+## Extended type system
+
+The fixed `bytes32[4]` container can support value types beyond the current three. The `valueType` discriminator is a `uint8` — 256 possible types. Potential additions:
+
+### Variable-width integers
+
+| Type | Encoding | Range | Use case |
+|---|---|---|---|
+| `ATTR_UINT8` | `data[0] = bytes32(uint256(value))` | 0–255 | Enum-like fields, small counters |
+| `ATTR_UINT16` | same | 0–65,535 | Years, port numbers |
+| `ATTR_UINT32` | same | 0–4.2B | Timestamps, IPv4 |
+| `ATTR_UINT64` | same | 0–1.8×10¹⁹ | Balances, large counters |
+| `ATTR_UINT128` | `data[0..1]` (first 16 bytes of data[0], or split across two words) | 0–3.4×10³⁸ | Token amounts, UUIDs |
+| `ATTR_UINT256` | `data[0]` (full word) | Full uint256 | Hashes, large numerics |
+
+All integer types use the same right-aligned big-endian encoding in `data[0]` — the width only affects **off-chain interpretation** (range validation, display). On-chain, the hash is identical regardless of declared width. The `valueType` tag lets indexers enforce range constraints and choose appropriate storage/sort strategies.
+
+A `ATTR_UINT128` that spans two words raises a design question: should the encoding use `data[0]` high 16 bytes + `data[1]` (split across words), or pack into `data[0]` right-aligned as a 128-bit value within a 256-bit word? Right-aligned in `data[0]` is simpler and preserves the single-word pattern for values ≤ 256 bits.
+
+### Boolean
+
+| Type | Encoding | Values |
+|---|---|---|
+| `ATTR_BOOL` | `data[0] = bytes32(uint256(0 or 1))` | `0` = false, `1` = true |
+
+Trivial to add. Same right-aligned encoding. Off-chain indexers treat `0` as false, non-zero as true (or strictly `1`).
+
+### Address
+
+| Type | Encoding |
+|---|---|
+| `ATTR_ADDRESS` | `data[0] = bytes32(uint256(uint160(addr)))` |
+
+Right-aligned, same as Solidity's native `abi.encode(address)`. Useful for owner references, linked accounts.
+
+### Bytes32 (raw hash / identifier)
+
+Already covered by `ATTR_ENTITY_KEY`, but a generic `ATTR_BYTES32` type could represent arbitrary 32-byte values without the entity-key semantic implication.
+
+### Signed integers
+
+| Type | Encoding |
+|---|---|
+| `ATTR_INT256` | `data[0] = bytes32(uint256(int256(value)))` — two's complement |
+
+Byte-level sorting does **not** match numeric ordering for signed integers (negative values have high bits set, sorting after positive values). Off-chain indexers must sign-extend for correct comparison. This is a known trade-off — the protocol provides deterministic byte ordering, not semantically correct numeric ordering for signed types.
+
+### Fixed-point / decimal
+
+Could be represented as a scaled integer (`ATTR_UINT` with an implicit decimal point at a fixed position, e.g., 18 decimals). No new encoding needed — the `valueType` tag tells indexers how to interpret the uint.
+
+## EIP-712 hash encoding
+
+**Current:** `keccak256(attr.value)` — hashes the dynamic bytes.
+
+**With `bytes32[4]`:** `keccak256(abi.encode(value[0], value[1], value[2], value[3]))` — hashes the four words. Same pattern as `Mime128` content type hashing.
+
+The `ATTRIBUTE_TYPEHASH` changes from:
+```
+"Attribute(bytes32 name,uint8 valueType,bytes value)"
+```
+to:
+```
+"Attribute(bytes32 name,uint8 valueType,bytes32[4] value)"
+```
+
+## Collision resistance
+
+The `valueType` discriminator is included in the EIP-712 hash:
+
+```solidity
+keccak256(abi.encode(ATTRIBUTE_TYPEHASH, name, valueType, keccak256(abi.encode(v[0], v[1], v[2], v[3]))))
+```
+
+This prevents cross-type collisions: a uint256 whose bytes happen to match a left-aligned string encoding will produce a different hash because `valueType` differs. Adding new types (ATTR_BOOL, ATTR_ADDRESS, etc.) automatically gets collision resistance from the existing discriminator — no changes to the hash structure needed.
+
+## Struct layout change
+
+```solidity
+// Before — dynamic
+struct Attribute {
+    Ident32 name;       // 1 word
+    uint8 valueType;    // 1 byte (padded to 1 word)
+    bytes value;        // dynamic — pointer + length + data
+}
+
+// After — fully fixed
+struct Attribute {
+    Ident32 name;       // 1 word
+    uint8 valueType;    // 1 byte (padded to 1 word)
+    bytes32[4] value;   // 4 words, inline
+}
+```
+
+The struct becomes fully fixed-size: 6 words in calldata. No pointer indirection, no length prefix, no dynamic ABI encoding.
+
+## Whether to wrap in a struct
+
+**Recommendation: bare `bytes32[4]`.** Unlike `Mime128` (single encoding, structural validation) or `Ident32` (single encoding, charset validation), attribute values have multiple encodings selected by `valueType`. A wrapper struct adds ceremony without preventing misuse — you'd still need to construct the `bytes32[4]` differently per type. The `valueType` field already provides the semantic tag.
+
+## Gas impact
+
+| Operation | Current (`bytes`) | Proposed (`bytes32[4]`) |
+|---|---|---|
+| ABI decode per attribute | Variable (offset + length + data) | Fixed (4 words inline) |
+| Hash computation | `keccak256(attr.value)` — variable length | `keccak256(abi.encode(v[0],v[1],v[2],v[3]))` — always 128 bytes |
+| Validation | Length checks per type | None (opaque) |
+
+The hash computation becomes **constant cost** regardless of value content — always hashing 128 bytes. Slightly more expensive for 32-byte values (currently hashing 32 bytes), but eliminates variable gas and makes batch operations predictable.
+
+`MAX_STRING_ATTR_SIZE` (currently 1024) becomes redundant — the fixed `bytes32[4]` enforces the 128-byte cap structurally. The constant and its length check can be deleted.
+
+## Decisions
+
+| Question | Decision | Rationale |
+|---|---|---|
+| Allow empty values? | **Yes** | All-zero `bytes32[4]` is valid. Attribute presence in the array is the signal; the value can be a zero/empty sentinel. |
+| Allow zero uint? | **Yes** | Zero is a valid numeric value. |
+| Remove `MAX_STRING_ATTR_SIZE`? | **Yes** | Redundant — 128-byte cap is structural. |
+| On-chain charset validation for strings? | **No** | Opaque bytes per ADR-API-004. Would need performant 128-byte UTF-8 validation to reconsider — not justified today. |
+| On-chain value validation? | **No** | Encoding correctness is the caller/SDK's responsibility. The contract hashes deterministically regardless of content. |

--- a/src/EntityHashing.sol
+++ b/src/EntityHashing.sol
@@ -61,13 +61,14 @@ library EntityHashing {
     uint8 public constant ATTR_ENTITY_KEY = 3;
 
     /// @dev A typed key-value pair attached to an entity. The `name` is a
-    /// bytes32-packed UTF-8 identifier (left-aligned, zero-padded).
+    /// validated Ident32 identifier. The `value` is a fixed 128-byte container
+    /// (bytes32[4]) — encoding is determined by `valueType` and enforced off-chain.
     /// Attributes must be sorted ascending by name for deterministic hash
     /// computation and name-uniqueness enforcement.
     struct Attribute {
         Ident32 name;
         uint8 valueType;
-        bytes value;
+        bytes32[4] value;
     }
 
     /// @dev On-chain entity commitment. Stores only the fields needed to
@@ -104,8 +105,6 @@ library EntityHashing {
     error EmptyBatch();
     /// @dev Reverted when attributes are not in strictly ascending name order.
     error AttributesNotSorted();
-    /// @dev Reverted when an attribute value has the wrong byte length for its type.
-    error InvalidValueLength(Ident32 name, uint8 valueType, uint256 length);
     /// @dev Reverted when an attribute's valueType is unrecognized (including 0 / uninitialized).
     error InvalidValueType(Ident32 name, uint8 valueType);
     /// @dev Reverted when opType is unrecognized (including 0 / uninitialized).
@@ -134,14 +133,14 @@ library EntityHashing {
     // -------------------------------------------------------------------------
 
     uint256 internal constant MAX_ATTRIBUTES = 32;
-    uint256 internal constant MAX_STRING_ATTR_SIZE = 1024;
 
     // -------------------------------------------------------------------------
     // Constants — EIP-712 typehashes
     // -------------------------------------------------------------------------
 
-    /// @dev keccak256("Attribute(bytes32 name,uint8 valueType,bytes value)")
-    bytes32 internal constant ATTRIBUTE_TYPEHASH = keccak256("Attribute(bytes32 name,uint8 valueType,bytes value)");
+    /// @dev keccak256("Attribute(bytes32 name,uint8 valueType,bytes32[4] value)")
+    bytes32 internal constant ATTRIBUTE_TYPEHASH =
+        keccak256("Attribute(bytes32 name,uint8 valueType,bytes32[4] value)");
 
     /// @dev keccak256("CoreHash(bytes32 entityKey,address creator,uint32 createdAt,bytes32[4] contentType,bytes payload,bytes32 attributesHash)")
     bytes32 internal constant CORE_HASH_TYPEHASH = keccak256(
@@ -213,18 +212,13 @@ library EntityHashing {
         validateIdent32(attr.name);
         if (attr.name <= prevName) revert AttributesNotSorted();
 
-        uint8 vt = attr.valueType;
-        uint256 len = attr.value.length;
-        if (vt == ATTR_UINT || vt == ATTR_ENTITY_KEY) {
-            if (len != 32) revert InvalidValueLength(attr.name, vt, len);
-        } else if (vt == ATTR_STRING) {
-            if (len > MAX_STRING_ATTR_SIZE) revert InvalidValueLength(attr.name, vt, len);
-        } else {
-            revert InvalidValueType(attr.name, vt);
+        if (attr.valueType < ATTR_UINT || attr.valueType > ATTR_ENTITY_KEY) {
+            revert InvalidValueType(attr.name, attr.valueType);
         }
 
+        bytes32 valueHash = keccak256(abi.encode(attr.value[0], attr.value[1], attr.value[2], attr.value[3]));
         bytes32 attrHash =
-            keccak256(abi.encode(ATTRIBUTE_TYPEHASH, Ident32.unwrap(attr.name), attr.valueType, keccak256(attr.value)));
+            keccak256(abi.encode(ATTRIBUTE_TYPEHASH, Ident32.unwrap(attr.name), attr.valueType, valueHash));
         return (attr.name, keccak256(abi.encodePacked(chain, attrHash)));
     }
 

--- a/test/unit/hashing/AttributeHash.t.sol
+++ b/test/unit/hashing/AttributeHash.t.sol
@@ -30,6 +30,10 @@ contract AttributeHashTest is Test, EntityRegistry {
         return chain;
     }
 
+    function _valueHash(bytes32[4] memory v) internal pure returns (bytes32) {
+        return keccak256(abi.encode(v[0], v[1], v[2], v[3]));
+    }
+
     // ---- Determinism ----
 
     function test_attributeHash_uint_deterministic() public view {
@@ -81,7 +85,7 @@ contract AttributeHashTest is Test, EntityRegistry {
                         EntityHashing.ATTRIBUTE_TYPEHASH,
                         Ident32.unwrap(attr.name),
                         attr.valueType,
-                        keccak256(attr.value)
+                        _valueHash(attr.value)
                     )
                 )
             )
@@ -99,7 +103,7 @@ contract AttributeHashTest is Test, EntityRegistry {
                         EntityHashing.ATTRIBUTE_TYPEHASH,
                         Ident32.unwrap(attr.name),
                         attr.valueType,
-                        keccak256(attr.value)
+                        _valueHash(attr.value)
                     )
                 )
             )
@@ -118,7 +122,7 @@ contract AttributeHashTest is Test, EntityRegistry {
                         EntityHashing.ATTRIBUTE_TYPEHASH,
                         Ident32.unwrap(attr.name),
                         attr.valueType,
-                        keccak256(attr.value)
+                        _valueHash(attr.value)
                     )
                 )
             )
@@ -138,10 +142,10 @@ contract AttributeHashTest is Test, EntityRegistry {
         EntityHashing.Attribute memory b = Lib.stringAttr("label", "hello");
 
         bytes32 hashA = keccak256(
-            abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, Ident32.unwrap(a.name), a.valueType, keccak256(a.value))
+            abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, Ident32.unwrap(a.name), a.valueType, _valueHash(a.value))
         );
         bytes32 hashB = keccak256(
-            abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, Ident32.unwrap(b.name), b.valueType, keccak256(b.value))
+            abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, Ident32.unwrap(b.name), b.valueType, _valueHash(b.value))
         );
         bytes32 chain = keccak256(abi.encodePacked(bytes32(0), hashA));
         chain = keccak256(abi.encodePacked(chain, hashB));
@@ -166,51 +170,11 @@ contract AttributeHashTest is Test, EntityRegistry {
 
     // ---- Value type validation ----
 
-    function test_attributeHash_revertsOnUintWrongLength() public {
-        EntityHashing.Attribute memory attr =
-            EntityHashing.Attribute({name: Lib.packName("count"), valueType: EntityHashing.ATTR_UINT, value: hex"01"});
-        vm.expectRevert(
-            abi.encodeWithSelector(EntityHashing.InvalidValueLength.selector, attr.name, EntityHashing.ATTR_UINT, 1)
-        );
-        _hashOne(attr);
-    }
-
-    function test_attributeHash_revertsOnEntityKeyWrongLength() public {
-        EntityHashing.Attribute memory attr = EntityHashing.Attribute({
-            name: Lib.packName("ref"), valueType: EntityHashing.ATTR_ENTITY_KEY, value: hex"abcd"
-        });
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                EntityHashing.InvalidValueLength.selector, attr.name, EntityHashing.ATTR_ENTITY_KEY, 2
-            )
-        );
-        _hashOne(attr);
-    }
-
-    function test_attributeHash_revertsOnStringTooLarge() public {
-        EntityHashing.Attribute memory attr = EntityHashing.Attribute({
-            name: Lib.packName("bio"), valueType: EntityHashing.ATTR_STRING, value: new bytes(1025)
-        });
-        vm.expectRevert(
-            abi.encodeWithSelector(
-                EntityHashing.InvalidValueLength.selector, attr.name, EntityHashing.ATTR_STRING, 1025
-            )
-        );
-        _hashOne(attr);
-    }
-
-    function test_attributeHash_acceptsStringAtMaxSize() public view {
-        _hashOne(
-            EntityHashing.Attribute({
-                name: Lib.packName("bio"), valueType: EntityHashing.ATTR_STRING, value: new bytes(1024)
-            })
-        );
-    }
-
     function test_attributeHash_revertsOnUninitializedValueType() public {
-        EntityHashing.Attribute memory attr = EntityHashing.Attribute({
-            name: Lib.packName("bad"), valueType: EntityHashing.UNINITIALIZED, value: abi.encode(uint256(1))
-        });
+        bytes32[4] memory v;
+        v[0] = bytes32(uint256(1));
+        EntityHashing.Attribute memory attr =
+            EntityHashing.Attribute({name: Lib.packName("bad"), valueType: EntityHashing.UNINITIALIZED, value: v});
         vm.expectRevert(
             abi.encodeWithSelector(EntityHashing.InvalidValueType.selector, attr.name, EntityHashing.UNINITIALIZED)
         );
@@ -219,8 +183,9 @@ contract AttributeHashTest is Test, EntityRegistry {
 
     function test_attributeHash_revertsOnValueTypeAboveRange() public {
         uint8 aboveRange = EntityHashing.ATTR_ENTITY_KEY + 1;
+        bytes32[4] memory v;
         EntityHashing.Attribute memory attr =
-            EntityHashing.Attribute({name: Lib.packName("bad"), valueType: aboveRange, value: hex"00"});
+            EntityHashing.Attribute({name: Lib.packName("bad"), valueType: aboveRange, value: v});
         vm.expectRevert(abi.encodeWithSelector(EntityHashing.InvalidValueType.selector, attr.name, aboveRange));
         _hashOne(attr);
     }
@@ -230,7 +195,7 @@ contract AttributeHashTest is Test, EntityRegistry {
     function _refHash(EntityHashing.Attribute memory attr) internal pure returns (bytes32) {
         return keccak256(
             abi.encode(
-                EntityHashing.ATTRIBUTE_TYPEHASH, Ident32.unwrap(attr.name), attr.valueType, keccak256(attr.value)
+                EntityHashing.ATTRIBUTE_TYPEHASH, Ident32.unwrap(attr.name), attr.valueType, _valueHash(attr.value)
             )
         );
     }
@@ -258,25 +223,26 @@ contract AttributeHashTest is Test, EntityRegistry {
 
     function test_attributeHash_fuzz_uint(bytes32 name, uint256 value) public {
         vm.assume(_isValidIdent(name));
-        EntityHashing.Attribute memory attr = EntityHashing.Attribute({
-            name: Ident32.wrap(name), valueType: EntityHashing.ATTR_UINT, value: abi.encode(value)
-        });
+        bytes32[4] memory v;
+        v[0] = bytes32(value);
+        EntityHashing.Attribute memory attr =
+            EntityHashing.Attribute({name: Ident32.wrap(name), valueType: EntityHashing.ATTR_UINT, value: v});
         (, bytes32 chain) = this.doAttributeHash(Ident32.wrap(bytes32(0)), bytes32(0), attr);
         assertEq(chain, _refChain(bytes32(0), _refHash(attr)));
     }
 
     function test_attributeHash_fuzz_entityKey(bytes32 name, bytes32 value) public {
         vm.assume(_isValidIdent(name));
-        EntityHashing.Attribute memory attr = EntityHashing.Attribute({
-            name: Ident32.wrap(name), valueType: EntityHashing.ATTR_ENTITY_KEY, value: abi.encode(value)
-        });
+        bytes32[4] memory v;
+        v[0] = value;
+        EntityHashing.Attribute memory attr =
+            EntityHashing.Attribute({name: Ident32.wrap(name), valueType: EntityHashing.ATTR_ENTITY_KEY, value: v});
         (, bytes32 chain) = this.doAttributeHash(Ident32.wrap(bytes32(0)), bytes32(0), attr);
         assertEq(chain, _refChain(bytes32(0), _refHash(attr)));
     }
 
-    function test_attributeHash_fuzz_string(bytes32 name, bytes calldata value) public {
+    function test_attributeHash_fuzz_string(bytes32 name, bytes32[4] calldata value) public {
         vm.assume(_isValidIdent(name));
-        vm.assume(value.length <= 1024);
         EntityHashing.Attribute memory attr =
             EntityHashing.Attribute({name: Ident32.wrap(name), valueType: EntityHashing.ATTR_STRING, value: value});
         (, bytes32 chain) = this.doAttributeHash(Ident32.wrap(bytes32(0)), bytes32(0), attr);

--- a/test/unit/hashing/CoreHash.t.sol
+++ b/test/unit/hashing/CoreHash.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {BlockNumber} from "../../../src/BlockNumber.sol";
+import {Ident32} from "../../../src/Ident32.sol";
 import {Mime128, encodeMime128} from "../../../src/types/Mime128.sol";
 import {Test} from "forge-std/Test.sol";
 import {Lib} from "../../utils/Lib.sol";
@@ -156,10 +157,20 @@ contract CoreHashTest is Test, EntityRegistry {
         attrs[1] = Lib.stringAttr("bbb", "val");
 
         bytes32 hashA = keccak256(
-            abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, attrs[0].name, attrs[0].valueType, keccak256(attrs[0].value))
+            abi.encode(
+                EntityHashing.ATTRIBUTE_TYPEHASH,
+                Ident32.unwrap(attrs[0].name),
+                attrs[0].valueType,
+                keccak256(abi.encode(attrs[0].value[0], attrs[0].value[1], attrs[0].value[2], attrs[0].value[3]))
+            )
         );
         bytes32 hashB = keccak256(
-            abi.encode(EntityHashing.ATTRIBUTE_TYPEHASH, attrs[1].name, attrs[1].valueType, keccak256(attrs[1].value))
+            abi.encode(
+                EntityHashing.ATTRIBUTE_TYPEHASH,
+                Ident32.unwrap(attrs[1].name),
+                attrs[1].valueType,
+                keccak256(abi.encode(attrs[1].value[0], attrs[1].value[1], attrs[1].value[2], attrs[1].value[3]))
+            )
         );
         bytes32 attrChain = keccak256(abi.encodePacked(bytes32(0), hashA));
         attrChain = keccak256(abi.encodePacked(attrChain, hashB));

--- a/test/utils/Lib.sol
+++ b/test/utils/Lib.sol
@@ -89,10 +89,9 @@ library Lib {
     }
 
     function uintAttr(string memory name, uint256 value) internal pure returns (EntityHashing.Attribute memory) {
-        return
-            EntityHashing.Attribute({
-                name: packName(name), valueType: EntityHashing.ATTR_UINT, value: abi.encode(value)
-            });
+        bytes32[4] memory v;
+        v[0] = bytes32(value);
+        return EntityHashing.Attribute({name: packName(name), valueType: EntityHashing.ATTR_UINT, value: v});
     }
 
     function stringAttr(string memory name, string memory value)
@@ -100,15 +99,20 @@ library Lib {
         pure
         returns (EntityHashing.Attribute memory)
     {
-        return EntityHashing.Attribute({
-            name: packName(name), valueType: EntityHashing.ATTR_STRING, value: bytes(value)
-        });
+        bytes memory b = bytes(value);
+        bytes32[4] memory v;
+        for (uint256 i = 0; i < b.length; i++) {
+            uint256 slot = i / 32;
+            uint256 offset = i % 32;
+            v[slot] |= bytes32(bytes1(b[i])) >> (offset * 8);
+        }
+        return EntityHashing.Attribute({name: packName(name), valueType: EntityHashing.ATTR_STRING, value: v});
     }
 
     function entityKeyAttr(string memory name, bytes32 value) internal pure returns (EntityHashing.Attribute memory) {
-        return EntityHashing.Attribute({
-            name: packName(name), valueType: EntityHashing.ATTR_ENTITY_KEY, value: abi.encode(value)
-        });
+        bytes32[4] memory v;
+        v[0] = value;
+        return EntityHashing.Attribute({name: packName(name), valueType: EntityHashing.ATTR_ENTITY_KEY, value: v});
     }
 
     function payload(uint256 size) internal pure returns (bytes memory) {


### PR DESCRIPTION
Related #28

- Changes `Attribute.value` from dynamic `bytes` to fixed `bytes32[4]` (128 bytes), making the `Attribute` struct fully fixed-size
- Removes per-type length validation (`InvalidValueLength`, `MAX_STRING_ATTR_SIZE`) — the value is an opaque blob, encoding correctness is the caller/SDK's responsibility
- Updates `ATTRIBUTE_TYPEHASH` from `bytes value` to `bytes32[4] value`
- Value hashing becomes constant-cost: always `keccak256(abi.encode(v[0], v[1], v[2], v[3]))` regardless of content
- Design document covers the three encoding patterns (uint, string, entity key), extended type system, and collision resistance via `valueType` discriminator

## Files

| File | Change |
|---|---|
| `src/EntityHashing.sol` | `Attribute.value`: `bytes` → `bytes32[4]`. `ATTRIBUTE_TYPEHASH` updated. Removed `InvalidValueLength` error, `MAX_STRING_ATTR_SIZE` constant, and per-type length checks in `attributeHash`. Value hash uses 4-word `abi.encode`. |
| `docs/value128-encoding.md` | Design doc: three encodings, validation philosophy (opaque), extended type system (variable-width ints, bool, address, signed), struct layout, gas impact, decisions |
| `test/utils/Lib.sol` | `uintAttr`/`entityKeyAttr` pack into `v[0]`. `stringAttr` packs left-aligned across 4 words. |
| `test/unit/hashing/AttributeHash.t.sol` | Removed length validation tests (4 tests). Added `_valueHash` helper. Manual EIP-712 encoding tests use 4-word value hash. Fuzz tests use `bytes32[4]` directly. |
| `test/unit/hashing/CoreHash.t.sol` | Manual EIP-712 encoding updated for `bytes32[4]` attribute values. |