### PR TITLE
Consolidate six operation events into single EntityOp

### DIFF
--- a/src/EntityRegistry.sol
+++ b/src/EntityRegistry.sol
@@ -54,20 +54,13 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
     // Events
     // -------------------------------------------------------------------------
 
-    event EntityCreated(
-        bytes32 indexed entityKey, address indexed owner, BlockNumber indexed expiresAt, bytes32 entityHash
+    event EntityOp(
+        bytes32 indexed entityKey,
+        uint8 indexed opType,
+        address indexed owner,
+        BlockNumber expiresAt,
+        bytes32 entityHash
     );
-    event EntityUpdated(
-        bytes32 indexed entityKey, address indexed owner, BlockNumber indexed expiresAt, bytes32 entityHash
-    );
-    event EntityExtended(
-        bytes32 indexed entityKey, address indexed owner, BlockNumber indexed newExpiresAt, bytes32 entityHash
-    );
-    event EntityTransferred(
-        bytes32 indexed entityKey, address indexed previousOwner, address indexed newOwner, bytes32 entityHash
-    );
-    event EntityDeleted(bytes32 indexed entityKey, address indexed owner, bytes32 entityHash);
-    event EntityExpired(bytes32 indexed entityKey, address indexed owner, bytes32 entityHash);
 
     // -------------------------------------------------------------------------
     // State — linked list pointers
@@ -326,7 +319,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
             coreHash: coreHash_
         });
 
-        emit EntityCreated(key, msg.sender, op.expiresAt, entityHash_);
+        emit EntityOp(key, EntityHashing.CREATE, msg.sender, op.expiresAt, entityHash_);
     }
 
     /// @dev Update an existing entity's payload, contentType, and attributes.
@@ -355,7 +348,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         c.coreHash = coreHash_;
         c.updatedAt = current;
 
-        emit EntityUpdated(key, c.owner, c.expiresAt, entityHash_);
+        emit EntityOp(key, EntityHashing.UPDATE, c.owner, c.expiresAt, entityHash_);
         return (key, entityHash_);
     }
 
@@ -383,7 +376,7 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
 
         bytes32 entityHash_ = _wrapEntityHash(c.coreHash, c.owner, current, op.expiresAt);
 
-        emit EntityExtended(key, c.owner, op.expiresAt, entityHash_);
+        emit EntityOp(key, EntityHashing.EXTEND, c.owner, op.expiresAt, entityHash_);
         return (key, entityHash_);
     }
 
@@ -409,13 +402,12 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
             revert EntityHashing.TransferToSelf(key);
         }
 
-        address previousOwner = c.owner;
         c.owner = op.newOwner;
         c.updatedAt = current;
 
         bytes32 entityHash_ = _wrapEntityHash(c.coreHash, op.newOwner, current, c.expiresAt);
 
-        emit EntityTransferred(key, previousOwner, op.newOwner, entityHash_);
+        emit EntityOp(key, EntityHashing.TRANSFER, op.newOwner, c.expiresAt, entityHash_);
         return (key, entityHash_);
     }
 
@@ -434,13 +426,14 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
         EntityHashing.Commitment storage c = _commitments[key];
         _guardEntityMutation(key, c, current);
 
-        // Snapshot the entity hash before deletion.
+        // Snapshot before deletion.
         bytes32 entityHash_ = _wrapEntityHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt);
         address owner = c.owner;
+        BlockNumber expiresAt = c.expiresAt;
 
         delete _commitments[key];
 
-        emit EntityDeleted(key, owner, entityHash_);
+        emit EntityOp(key, EntityHashing.DELETE, owner, expiresAt, entityHash_);
         return (key, entityHash_);
     }
 
@@ -460,10 +453,11 @@ contract EntityRegistry is EIP712("Arkiv EntityRegistry", "1") {
 
         bytes32 entityHash_ = _wrapEntityHash(c.coreHash, c.owner, c.updatedAt, c.expiresAt);
         address owner = c.owner;
+        BlockNumber expiresAt = c.expiresAt;
 
         delete _commitments[key];
 
-        emit EntityExpired(key, owner, entityHash_);
+        emit EntityOp(key, EntityHashing.EXPIRE, owner, expiresAt, entityHash_);
         return (key, entityHash_);
     }
 }

--- a/test/unit/ops/Create.t.sol
+++ b/test/unit/ops/Create.t.sol
@@ -104,12 +104,12 @@ contract CreateTest is Test, EntityRegistry {
     // Event
     // =========================================================================
 
-    function test_create_emitsEntityCreated() public {
+    function test_create_emitsEntityOp() public {
         EntityHashing.Op memory op = _defaultOp();
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, true);
-        emit EntityCreated(STUB_KEY, alice, expiresAt, STUB_ENTITY_HASH);
+        emit EntityOp(STUB_KEY, EntityHashing.CREATE, alice, expiresAt, STUB_ENTITY_HASH);
         this.doCreate(op);
     }
 

--- a/test/unit/ops/Delete.t.sol
+++ b/test/unit/ops/Delete.t.sol
@@ -85,12 +85,12 @@ contract DeleteTest is Test, EntityRegistry {
     // Event
     // =========================================================================
 
-    function test_delete_emitsEntityDeleted() public {
+    function test_delete_emitsEntityOp() public {
         EntityHashing.Op memory op = Lib.deleteOp(testKey);
 
         vm.prank(alice);
-        vm.expectEmit(true, true, false, false);
-        emit EntityDeleted(testKey, alice, bytes32(0));
+        vm.expectEmit(true, true, true, false);
+        emit EntityOp(testKey, EntityHashing.DELETE, alice, expiresAt, bytes32(0));
         this.doDelete(op);
     }
 }

--- a/test/unit/ops/Delete.t.sol
+++ b/test/unit/ops/Delete.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {BlockNumber, currentBlock} from "../../../src/BlockNumber.sol";
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {Lib} from "../../utils/Lib.sol";
 import {EntityHashing} from "../../../src/EntityHashing.sol";
 import {EntityRegistry} from "../../../src/EntityRegistry.sol";
@@ -89,8 +89,17 @@ contract DeleteTest is Test, EntityRegistry {
         EntityHashing.Op memory op = Lib.deleteOp(testKey);
 
         vm.prank(alice);
-        vm.expectEmit(true, true, true, false);
-        emit EntityOp(testKey, EntityHashing.DELETE, alice, expiresAt, bytes32(0));
-        this.doDelete(op);
+        vm.recordLogs();
+        (, bytes32 entityHash_) = this.doDelete(op);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+        assertEq(logs[0].topics[0], EntityOp.selector);
+        assertEq(logs[0].topics[1], testKey);
+        assertEq(logs[0].topics[2], bytes32(uint256(EntityHashing.DELETE)));
+        assertEq(logs[0].topics[3], bytes32(uint256(uint160(alice))));
+        (BlockNumber emittedExpiry, bytes32 emittedHash) = abi.decode(logs[0].data, (BlockNumber, bytes32));
+        assertEq(BlockNumber.unwrap(emittedExpiry), BlockNumber.unwrap(expiresAt));
+        assertEq(emittedHash, entityHash_);
     }
 }

--- a/test/unit/ops/Expire.t.sol
+++ b/test/unit/ops/Expire.t.sol
@@ -75,9 +75,10 @@ contract ExpireTest is Test, EntityRegistry {
     // Event
     // =========================================================================
 
-    function test_expire_emitsEntityExpired() public {
-        vm.expectEmit(true, true, false, false);
-        emit EntityExpired(testKey, alice, bytes32(0));
+    function test_expire_emitsEntityOp() public {
+        vm.roll(BlockNumber.unwrap(expiresAt));
+        vm.expectEmit(true, true, true, false);
+        emit EntityOp(testKey, EntityHashing.EXPIRE, alice, expiresAt, bytes32(0));
         this.doExpire(testKey);
     }
 }

--- a/test/unit/ops/Expire.t.sol
+++ b/test/unit/ops/Expire.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {BlockNumber, currentBlock} from "../../../src/BlockNumber.sol";
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {Lib} from "../../utils/Lib.sol";
 import {EntityHashing} from "../../../src/EntityHashing.sol";
 import {EntityRegistry} from "../../../src/EntityRegistry.sol";
@@ -77,8 +77,17 @@ contract ExpireTest is Test, EntityRegistry {
 
     function test_expire_emitsEntityOp() public {
         vm.roll(BlockNumber.unwrap(expiresAt));
-        vm.expectEmit(true, true, true, false);
-        emit EntityOp(testKey, EntityHashing.EXPIRE, alice, expiresAt, bytes32(0));
-        this.doExpire(testKey);
+        vm.recordLogs();
+        (, bytes32 entityHash_) = this.doExpire(testKey);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+        assertEq(logs[0].topics[0], EntityOp.selector);
+        assertEq(logs[0].topics[1], testKey);
+        assertEq(logs[0].topics[2], bytes32(uint256(EntityHashing.EXPIRE)));
+        assertEq(logs[0].topics[3], bytes32(uint256(uint160(alice))));
+        (BlockNumber emittedExpiry, bytes32 emittedHash) = abi.decode(logs[0].data, (BlockNumber, bytes32));
+        assertEq(BlockNumber.unwrap(emittedExpiry), BlockNumber.unwrap(expiresAt));
+        assertEq(emittedHash, entityHash_);
     }
 }

--- a/test/unit/ops/Extend.t.sol
+++ b/test/unit/ops/Extend.t.sol
@@ -148,13 +148,13 @@ contract ExtendTest is Test, EntityRegistry {
     // Event
     // =========================================================================
 
-    function test_extend_emitsEntityExtended() public {
+    function test_extend_emitsEntityOp() public {
         BlockNumber newExpiry = expiresAt + BlockNumber.wrap(500);
         EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, false);
-        emit EntityExtended(testKey, alice, newExpiry, bytes32(0));
+        emit EntityOp(testKey, EntityHashing.EXTEND, alice, newExpiry, bytes32(0));
         this.doExtend(op);
     }
 }

--- a/test/unit/ops/Extend.t.sol
+++ b/test/unit/ops/Extend.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {BlockNumber, currentBlock} from "../../../src/BlockNumber.sol";
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {Lib} from "../../utils/Lib.sol";
 import {EntityHashing} from "../../../src/EntityHashing.sol";
 import {EntityRegistry} from "../../../src/EntityRegistry.sol";
@@ -153,8 +153,17 @@ contract ExtendTest is Test, EntityRegistry {
         EntityHashing.Op memory op = Lib.extendOp(testKey, newExpiry);
 
         vm.prank(alice);
-        vm.expectEmit(true, true, true, false);
-        emit EntityOp(testKey, EntityHashing.EXTEND, alice, newExpiry, bytes32(0));
-        this.doExtend(op);
+        vm.recordLogs();
+        (, bytes32 entityHash_) = this.doExtend(op);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+        assertEq(logs[0].topics[0], EntityOp.selector);
+        assertEq(logs[0].topics[1], testKey);
+        assertEq(logs[0].topics[2], bytes32(uint256(EntityHashing.EXTEND)));
+        assertEq(logs[0].topics[3], bytes32(uint256(uint160(alice))));
+        (BlockNumber emittedExpiry, bytes32 emittedHash) = abi.decode(logs[0].data, (BlockNumber, bytes32));
+        assertEq(BlockNumber.unwrap(emittedExpiry), BlockNumber.unwrap(newExpiry));
+        assertEq(emittedHash, entityHash_);
     }
 }

--- a/test/unit/ops/Transfer.t.sol
+++ b/test/unit/ops/Transfer.t.sol
@@ -159,12 +159,12 @@ contract TransferTest is Test, EntityRegistry {
     // Event
     // =========================================================================
 
-    function test_transfer_emitsEntityTransferred() public {
+    function test_transfer_emitsEntityOp() public {
         EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, false);
-        emit EntityTransferred(testKey, alice, bob, bytes32(0));
+        emit EntityOp(testKey, EntityHashing.TRANSFER, bob, expiresAt, bytes32(0));
         this.doTransfer(op);
     }
 }

--- a/test/unit/ops/Transfer.t.sol
+++ b/test/unit/ops/Transfer.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {BlockNumber, currentBlock} from "../../../src/BlockNumber.sol";
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {Lib} from "../../utils/Lib.sol";
 import {EntityHashing} from "../../../src/EntityHashing.sol";
 import {EntityRegistry} from "../../../src/EntityRegistry.sol";
@@ -163,8 +163,17 @@ contract TransferTest is Test, EntityRegistry {
         EntityHashing.Op memory op = Lib.transferOp(testKey, bob);
 
         vm.prank(alice);
-        vm.expectEmit(true, true, true, false);
-        emit EntityOp(testKey, EntityHashing.TRANSFER, bob, expiresAt, bytes32(0));
-        this.doTransfer(op);
+        vm.recordLogs();
+        (, bytes32 entityHash_) = this.doTransfer(op);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+        assertEq(logs[0].topics[0], EntityOp.selector);
+        assertEq(logs[0].topics[1], testKey);
+        assertEq(logs[0].topics[2], bytes32(uint256(EntityHashing.TRANSFER)));
+        assertEq(logs[0].topics[3], bytes32(uint256(uint160(bob))));
+        (BlockNumber emittedExpiry, bytes32 emittedHash) = abi.decode(logs[0].data, (BlockNumber, bytes32));
+        assertEq(BlockNumber.unwrap(emittedExpiry), BlockNumber.unwrap(expiresAt));
+        assertEq(emittedHash, entityHash_);
     }
 }

--- a/test/unit/ops/Update.t.sol
+++ b/test/unit/ops/Update.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {BlockNumber, currentBlock} from "../../../src/BlockNumber.sol";
-import {Test} from "forge-std/Test.sol";
+import {Test, Vm} from "forge-std/Test.sol";
 import {Lib} from "../../utils/Lib.sol";
 import {EntityHashing} from "../../../src/EntityHashing.sol";
 import {EntityRegistry} from "../../../src/EntityRegistry.sol";
@@ -144,9 +144,18 @@ contract UpdateTest is Test, EntityRegistry {
         EntityHashing.Op memory op = _simpleUpdateOp();
 
         vm.prank(alice);
-        vm.expectEmit(true, true, true, false);
-        emit EntityOp(testKey, EntityHashing.UPDATE, alice, expiresAt, bytes32(0));
-        this.doUpdate(op);
+        vm.recordLogs();
+        (, bytes32 entityHash_) = this.doUpdate(op);
+
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        assertEq(logs.length, 1);
+        assertEq(logs[0].topics[0], EntityOp.selector);
+        assertEq(logs[0].topics[1], testKey);
+        assertEq(logs[0].topics[2], bytes32(uint256(EntityHashing.UPDATE)));
+        assertEq(logs[0].topics[3], bytes32(uint256(uint160(alice))));
+        (BlockNumber emittedExpiry, bytes32 emittedHash) = abi.decode(logs[0].data, (BlockNumber, bytes32));
+        assertEq(BlockNumber.unwrap(emittedExpiry), BlockNumber.unwrap(expiresAt));
+        assertEq(emittedHash, entityHash_);
     }
 
     // =========================================================================

--- a/test/unit/ops/Update.t.sol
+++ b/test/unit/ops/Update.t.sol
@@ -140,12 +140,12 @@ contract UpdateTest is Test, EntityRegistry {
     // Event
     // =========================================================================
 
-    function test_update_emitsEntityUpdated() public {
+    function test_update_emitsEntityOp() public {
         EntityHashing.Op memory op = _simpleUpdateOp();
 
         vm.prank(alice);
         vm.expectEmit(true, true, true, false);
-        emit EntityUpdated(testKey, alice, expiresAt, bytes32(0));
+        emit EntityOp(testKey, EntityHashing.UPDATE, alice, expiresAt, bytes32(0));
         this.doUpdate(op);
     }
 


### PR DESCRIPTION
Ref #23 

- Replaces `EntityCreated`, `EntityUpdated`, `EntityExtended`, `EntityTransferred`, `EntityDeleted`, `EntityExpired` with a single `EntityOp` event
- Consistent indexed fields across all operations: `(entityKey, opType, owner)` — uses existing `EntityHashing` op constants as the discriminator
- `expiresAt` and `entityHash` in non-indexed data fields, always present
- `owner` always reflects post-operation state (new owner for transfers)
- Event tests upgraded from partial field checks (`expectEmit` with `false`) to full field validation via `vm.recordLogs()`

## Event

```solidity
event EntityOp(
    bytes32 indexed entityKey,
    uint8   indexed opType,
    address indexed owner,
    BlockNumber expiresAt,
    bytes32 entityHash
);
```

| Topic | Field | Meaning |
|---|---|---|
| `topic[0]` | selector | `EntityOp` event signature |
| `topic[1]` | `entityKey` | Which entity |
| `topic[2]` | `opType` | Which operation (CREATE=0 through EXPIRE=5) |
| `topic[3]` | `owner` | Post-operation owner |
| data | `expiresAt`, `entityHash` | Post-operation expiry + verification hash |

## Files

| File | Change |
|---|---|
| `src/EntityRegistry.sol` | 6 event definitions → 1. 6 emit patterns → 1 consistent pattern. Removed dead `previousOwner` variable from transfer. Added `expiresAt` snapshot in delete/expire before storage deletion. |
| `test/unit/ops/Create.t.sol` | Event name updated, opType added |
| `test/unit/ops/Update.t.sol` | `vm.recordLogs()` — validates all 3 topics + both data fields |
| `test/unit/ops/Extend.t.sol` | Same — validates `newExpiry` in data field |
| `test/unit/ops/Transfer.t.sol` | Same — validates `bob` (new owner) in topic, `expiresAt` in data |
| `test/unit/ops/Delete.t.sol` | Same — validates snapshotted `expiresAt` in data |
| `test/unit/ops/Expire.t.sol` | Same — validates snapshotted `expiresAt` in data, adds `vm.roll` |